### PR TITLE
Add option to disable GET request cache

### DIFF
--- a/.changeset/heavy-lies-retire.md
+++ b/.changeset/heavy-lies-retire.md
@@ -1,0 +1,5 @@
+---
+'@apollo/datasource-rest': minor
+---
+
+Add option to disable GET request cache

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,5 +4,6 @@
 *.md
 
 dist/
+coverage/
 
 .volta

--- a/README.md
+++ b/README.md
@@ -46,11 +46,6 @@ class MoviesAPI extends RESTDataSource {
 ### API Reference
 To see the all the properties and functions that can be overridden, the [source code](https://github.com/apollographql/apollo-server/tree/main/packages/apollo-datasource-rest) is always the best option.
 
-#### Constructor Parameters
-##### `httpFetch`
-
-Optional constructor option which allows overriding the `fetch` implementation used when calling data sources.
-
 #### Properties
 ##### `baseURL`
 Optional value to use for all the REST calls. If it is set in your class implementation, this base URL is used as the prefix for all calls. If it is not set, then the value passed to the REST call is exactly the value used.
@@ -71,10 +66,10 @@ class MoviesAPI extends RESTDataSource {
 ```
 
 ##### `requestCacheEnabled`
-By default, `RESTDataSource` caches all outgoing GET **requests** in a separate memoized cache from the regular response cache. It does this to prevent duplicate calls that might happen in rapid succession.
-If a request is made with the same cache key (URL by default) with an HTTP method other than GET, the cached request is then cleared.
+By default, `RESTDataSource` caches all outgoing GET **requests** in a separate memoized cache from the regular response cache. It makes the assumption that all responses from HTTP GET calls are cacheable by their URL.
+If a request is made with the same cache key (URL by default) but with an HTTP method other than GET, the cached request is then cleared.
 
-If you would like to disable the GET request cache, set the `requestCacheEnabled` property to `false`.
+If you would like to disable the GET request cache, set the `requestCacheEnabled` property to `false`. You might want to do this if your API is not actually cacheable or your data changes over time.
 
 ```js title="requestCacheEnabled.js"
 class MoviesAPI extends RESTDataSource {

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ class MoviesAPI extends RESTDataSource {
 ```
 
 ### API Reference
-To see the all the properties and functions that can be overridden, the [source code](https://github.com/apollographql/apollo-server/tree/main/packages/apollo-datasource-rest) is always the best option.
+To see the all the properties and functions that can be overridden, the [source code](https://github.com/apollographql/datasource-rest/tree/main/src/RESTDataSource.ts) is always the best option.
 
 #### Properties
 ##### `baseURL`
@@ -98,7 +98,15 @@ For example, you could use this to use header fields as part of the cache key. E
 This method is invoked just before the fetch call is made. If a `Promise` is returned from this method it will wait until the promise is completed to continue executing the request.
 
 ##### `cacheOptionsFor`
-Allows setting the `CacheOptions` to be used for each request/response in the HTTPCache. This is separate from the request-only cache.
+Allows setting the `CacheOptions` to be used for each request/response in the HTTPCache. This is separate from the request-only cache. You can use this to set the TTL.
+
+```javascript
+override cacheOptionsFor() {
+    return {
+        ttl: 1
+    }
+}
+```
 
 ##### `didReceiveResponse`
 By default, this method checks if the response was returned successfully and parses the response into the result object. If the response had an error, it detects which type of HTTP error and throws the error result.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,76 @@ class MoviesAPI extends RESTDataSource {
 }
 ```
 
+### API Reference
+To see the all the properties and functions that can be overridden, the [source code](https://github.com/apollographql/apollo-server/tree/main/packages/apollo-datasource-rest) is always the best option.
+
+#### Constructor Parameters
+##### `httpFetch`
+
+Optional constructor option which allows overriding the `fetch` implementation used when calling data sources.
+
+#### Properties
+##### `baseURL`
+Optional value to use for all the REST calls. If it is set in your class implementation, this base URL is used as the prefix for all calls. If it is not set, then the value passed to the REST call is exactly the value used.
+
+```js title="baseURL.js"
+class MoviesAPI extends RESTDataSource {
+  constructor() {
+    super();
+    this.baseURL = 'https://movies-api.example.com/';
+  }
+  // GET
+  async getMovie(id) {
+    return this.get(
+      `movies/${encodeURIComponent(id)}` // path
+    );
+  }
+}
+```
+
+##### `requestCacheEnabled`
+By default, `RESTDataSource` caches all outgoing GET **requests** in a separate memoized cache from the regular response cache. It does this to prevent duplicate calls that might happen in rapid succession.
+If a request is made with the same cache key (URL by default) with an HTTP method other than GET, the cached request is then cleared.
+
+If you would like to disable the GET request cache, set the `requestCacheEnabled` property to `false`.
+
+```js title="requestCacheEnabled.js"
+class MoviesAPI extends RESTDataSource {
+  constructor() {
+    super();
+    // Defaults to true
+    this.requestCacheEnabled = false;
+  }
+  // Outgoing requests are never cached, however the response cache is still enabled
+  async getMovie(id) {
+    return this.get(
+      `https://movies-api.example.com/movies/${encodeURIComponent(id)}` // path
+    );
+  }
+}
+```
+
+#### Methods
+
+##### `cacheKeyFor`
+By default, `RESTDatasource` uses the full request URL as the cache key. Override this method to remove query parameters or compute a custom cache key.
+
+For example, you could use this to use header fields as part of the cache key. Even though we do validate header fields and don't serve responses from cache when they don't match, new responses overwrite old ones with different header fields.
+
+##### `willSendRequest`
+This method is invoked just before the fetch call is made. If a `Promise` is returned from this method it will wait until the promise is completed to continue executing the request.
+
+##### `cacheOptionsFor`
+Allows setting the `CacheOptions` to be used for each request/response in the HTTPCache. This is separate from the request-only cache.
+
+##### `didReceiveResponse`
+By default, this method checks if the response was returned successfully and parses the response into the result object. If the response had an error, it detects which type of HTTP error and throws the error result.
+
+If you override this behavior, be sure to implement the proper error handling.
+
+##### `didEncounterError`
+By default, this method just throws the `error` it was given. If you override this method, you can choose to either perform some additional logic and still throw, or to swallow the error by not throwing the error result.
+
 ### HTTP Methods
 
 The `get` method on the [`RESTDataSource`](https://github.com/apollographql/datasource-rest/tree/main/src/RESTDataSource.ts) makes an HTTP `GET` request. Similarly, there are methods built-in to allow for `POST`, `PUT`, `PATCH`, and `DELETE` requests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/datasource-rest",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/datasource-rest",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -769,7 +769,7 @@ describe('RESTDataSource', () => {
       it('allows setting a short TTL for the cache', async () => {
         // nock depends on process.nextTick
         jest.useFakeTimers({ doNotFake: ['nextTick'] });
-        
+
         const dataSource = new (class extends RESTDataSource {
           override baseURL = 'https://api.example.com';
           override requestCacheEnabled = false;
@@ -790,7 +790,7 @@ describe('RESTDataSource', () => {
         await dataSource.getFoo(1);
 
         // expire the cache (note: 999ms, just shy of the 1s ttl, will reliably fail this test)
-        jest.advanceTimersByTime(1000);        
+        jest.advanceTimersByTime(1000);
 
         // Call a second time which should be invalid now
         await expect(dataSource.getFoo(1)).rejects.toThrow();

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -1,6 +1,7 @@
 // import fetch, { Request } from 'node-fetch';
 import {
-  AuthenticationError, CacheOptions,
+  AuthenticationError,
+  CacheOptions,
   DataSourceConfig,
   ForbiddenError,
   RequestOptions,
@@ -742,7 +743,7 @@ describe('RESTDataSource', () => {
 
     describe('http cache', () => {
       it('allows setting cache options for each request', async () => {
-        const dataSource = new class extends RESTDataSource {
+        const dataSource = new (class extends RESTDataSource {
           override baseURL = 'https://api.example.com';
           override requestCacheEnabled = false;
 
@@ -756,7 +757,7 @@ describe('RESTDataSource', () => {
               ttl: 1000000,
             };
           }
-        }();
+        })();
 
         nock(apiUrl).get('/foo/1').reply(200);
         await dataSource.getFoo(1);
@@ -766,7 +767,7 @@ describe('RESTDataSource', () => {
       });
 
       it('allows setting a short TTL for the cache', async () => {
-        const dataSource = new class extends RESTDataSource {
+        const dataSource = new (class extends RESTDataSource {
           override baseURL = 'https://api.example.com';
           override requestCacheEnabled = false;
 
@@ -780,7 +781,7 @@ describe('RESTDataSource', () => {
               ttl: 1,
             };
           }
-        }();
+        })();
 
         nock(apiUrl).get('/foo/1').reply(200);
         await dataSource.getFoo(1);
@@ -789,9 +790,7 @@ describe('RESTDataSource', () => {
         await new Promise((r) => setTimeout(r, 2000));
 
         // Call a second time which should be invalid now
-        await expect(dataSource.getFoo(1))
-            .rejects
-            .toThrow();
+        await expect(dataSource.getFoo(1)).rejects.toThrow();
       });
     });
   });

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -1,6 +1,6 @@
 // import fetch, { Request } from 'node-fetch';
 import {
-  AuthenticationError,
+  AuthenticationError, CacheOptions,
   DataSourceConfig,
   ForbiddenError,
   RequestOptions,
@@ -742,7 +742,7 @@ describe('RESTDataSource', () => {
 
     describe('http cache', () => {
       it('allows setting cache options for each request', async () => {
-        const dataSource = new (class extends RESTDataSource {
+        const dataSource = new class extends RESTDataSource {
           override baseURL = 'https://api.example.com';
           override requestCacheEnabled = false;
 
@@ -751,13 +751,12 @@ describe('RESTDataSource', () => {
           }
 
           // Set a long TTL for every request
-          // @ts-ignore
-          override cacheOptionsFor(_, __): CacheOptions | undefined {
+          override cacheOptionsFor(): CacheOptions | undefined {
             return {
               ttl: 1000000,
             };
           }
-        })();
+        }();
 
         nock(apiUrl).get('/foo/1').reply(200);
         await dataSource.getFoo(1);
@@ -767,7 +766,7 @@ describe('RESTDataSource', () => {
       });
 
       it('allows setting a short TTL for the cache', async () => {
-        const dataSource = new (class extends RESTDataSource {
+        const dataSource = new class extends RESTDataSource {
           override baseURL = 'https://api.example.com';
           override requestCacheEnabled = false;
 
@@ -776,13 +775,12 @@ describe('RESTDataSource', () => {
           }
 
           // Set a short TTL for every request
-          // @ts-ignore
-          override cacheOptionsFor(_, __): CacheOptions | undefined {
+          override cacheOptionsFor(): CacheOptions | undefined {
             return {
               ttl: 1,
             };
           }
-        })();
+        }();
 
         nock(apiUrl).get('/foo/1').reply(200);
         await dataSource.getFoo(1);


### PR DESCRIPTION
Back-port from Apollo Server 3 repo: https://github.com/apollographql/apollo-server/pull/6650

Fixes https://github.com/apollographql/apollo-server/issues/6603

By default, `RESTDataSource` caches all outgoing GET **requests** in a separate memoized cache from the regular response cache. It makes the assumption that all responses from HTTP GET calls are cacheable by their URL.
If a request is made with the same cache key (URL by default) but with an HTTP method other than GET, the cached request is then cleared.

This change adds a new class property `requestCacheEnabled` (which defaults to `true` to match current behavior) which allows users to disable the cache. You might want to do this if your API is not actually cacheable or your data changes over time.


Separately it documents this feature exists and adds more info about how to set a TTL for the entire HTTP cache