### PR TITLE
Rename property for RESTDataSource

### DIFF
--- a/.changeset/brave-cows-attend.md
+++ b/.changeset/brave-cows-attend.md
@@ -1,0 +1,7 @@
+---
+'@apollo/datasource-rest': minor
+---
+
+Rename `requestCacheEnabled` to `memoizeGetRequests`. Acknowledging this is
+actually a breaking change, but this package has been live for a weekend with
+nothing recommending its usage yet.

--- a/README.md
+++ b/README.md
@@ -65,25 +65,26 @@ class MoviesAPI extends RESTDataSource {
 }
 ```
 
-##### `requestCacheEnabled`
+##### `memoizeGetRequests`
 By default, `RESTDataSource` caches all outgoing GET **requests** in a separate memoized cache from the regular response cache. It makes the assumption that all responses from HTTP GET calls are cacheable by their URL.
 If a request is made with the same cache key (URL by default) but with an HTTP method other than GET, the cached request is then cleared.
 
-If you would like to disable the GET request cache, set the `requestCacheEnabled` property to `false`. You might want to do this if your API is not actually cacheable or your data changes over time.
+If you would like to disable the GET request cache, set the `memoizeGetRequests` property to `false`. You might want to do this if your API is not actually cacheable or your data changes over time.
 
-```js title="requestCacheEnabled.js"
+```js title="memoizeGetRequests.js"
 class MoviesAPI extends RESTDataSource {
-  constructor() {
-    super();
-    // Defaults to true
-    this.requestCacheEnabled = false;
-  }
-  // Outgoing requests are never cached, however the response cache is still enabled
-  async getMovie(id) {
-    return this.get(
-      `https://movies-api.example.com/movies/${encodeURIComponent(id)}` // path
-    );
-  }
+    constructor() {
+        super();
+        // Defaults to true
+        this.memoizeGetRequests = false;
+    }
+
+    // Outgoing requests are never cached, however the response cache is still enabled
+    async getMovie(id) {
+        return this.get(
+            `https://movies-api.example.com/movies/${encodeURIComponent(id)}` // path
+        );
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,18 +73,18 @@ If you would like to disable the GET request cache, set the `memoizeGetRequests`
 
 ```js title="memoizeGetRequests.js"
 class MoviesAPI extends RESTDataSource {
-    constructor() {
-        super();
-        // Defaults to true
-        this.memoizeGetRequests = false;
-    }
+  constructor() {
+    super();
+    // Defaults to true
+    this.memoizeGetRequests = false;
+  }
 
-    // Outgoing requests are never cached, however the response cache is still enabled
-    async getMovie(id) {
-        return this.get(
-            `https://movies-api.example.com/movies/${encodeURIComponent(id)}` // path
-        );
-    }
+  // Outgoing requests are never cached, however the response cache is still enabled
+  async getMovie(id) {
+    return this.get(
+      `https://movies-api.example.com/movies/${encodeURIComponent(id)}` // path
+    );
+  }
 }
 ```
 
@@ -103,9 +103,9 @@ Allows setting the `CacheOptions` to be used for each request/response in the HT
 
 ```javascript
 override cacheOptionsFor() {
-    return {
-        ttl: 1
-    }
+  return {
+    ttl: 1
+  }
 }
 ```
 

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -58,7 +58,7 @@ export abstract class RESTDataSource {
   httpCache: HTTPCache;
   memoizedResults = new Map<string, Promise<any>>();
   baseURL?: string;
-  requestCacheEnabled: boolean = true;
+  memoizeGetRequests: boolean = true;
 
   constructor(config?: DataSourceConfig) {
     this.httpCache = new HTTPCache(config?.cache, config?.fetch);
@@ -260,7 +260,7 @@ export abstract class RESTDataSource {
 
     // Cache GET requests based on the calculated cache key
     // Disabling the request cache does not disable the response cache
-    if (this.requestCacheEnabled) {
+    if (this.memoizeGetRequests) {
       if (request.method === 'GET') {
         let promise = this.memoizedResults.get(cacheKey);
         if (promise) return promise;

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -590,7 +590,7 @@ describe('RESTDataSource', () => {
       it('allows disabling the GET cache', async () => {
         const dataSource = new (class extends RESTDataSource {
           override baseURL = 'https://api.example.com';
-          override requestCacheEnabled = false;
+          override memoizeGetRequests = false;
 
           getFoo(id: number) {
             return this.get(`foo/${id}`);
@@ -745,7 +745,7 @@ describe('RESTDataSource', () => {
       it('allows setting cache options for each request', async () => {
         const dataSource = new (class extends RESTDataSource {
           override baseURL = 'https://api.example.com';
-          override requestCacheEnabled = false;
+          override memoizeGetRequests = false;
 
           getFoo(id: number) {
             return this.get(`foo/${id}`);
@@ -772,7 +772,7 @@ describe('RESTDataSource', () => {
 
         const dataSource = new (class extends RESTDataSource {
           override baseURL = 'https://api.example.com';
-          override requestCacheEnabled = false;
+          override memoizeGetRequests = false;
 
           getFoo(id: number) {
             return this.get(`foo/${id}`);


### PR DESCRIPTION
Back-port of https://github.com/apollographql/apollo-server/pull/6834

----------
Rename property for RESTDataSource from `requestCacheEnabled` to `memoizeGetRequests`

From the initial PR, the name of the new property was a little confusing since there are actually two caches, but what is being cached is the response data in the end

Original PR https://github.com/apollographql/datasource-rest/pull/3