### PR TITLE
Lock node-fetch to major v2

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -25,5 +25,10 @@
       "matchPackageNames": ["@types/node"],
       "allowedVersions": "14.x"
     },
+    // v3 is ESM only
+    {
+      "matchPackageNames": ["node-fetch"],
+      "allowedVersions": "2.x"
+    },
   ],
 }


### PR DESCRIPTION
`node-fetch@3` is ESM only. We still intend to support CJS users for the forseeable future.