### PR TITLE
Use npx for build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "node": ">=14.0"
   },
   "scripts": {
-    "build": "tsc --build tsconfig.build.json",
+    "//": "#use npx here to ensure that non-TS users triggering the postinstall script don't need to install TypeScript globally or in their project",
+    "build": "npx -p typescript tsc --build tsconfig.build.json",
     "clean": "git clean -dfqX",
     "install-with-npm-8.5": "npm i -g npm@^8.5.0 && npm i",
     "postinstall": "npm run build",


### PR DESCRIPTION
The use of `tsc` in the postinstall script of this package means that even non-TS users will ultimately try to build the package on install. This doesn't really make sense, and can even break if typescript isn't transitively installed into their node_modules.

More info: https://github.com/apollographql/typescript-repo-template/pull/83