### PR TITLE
Remove postinstall script

### DIFF
--- a/.changeset/gold-snakes-shout.md
+++ b/.changeset/gold-snakes-shout.md
@@ -1,0 +1,5 @@
+---
+'@apollo/datasource-rest': patch
+---
+
+Fix installation into non-TS repositories

--- a/package.json
+++ b/package.json
@@ -18,11 +18,9 @@
     "node": ">=14.0"
   },
   "scripts": {
-    "//": "#use npx here to ensure that non-TS users triggering the postinstall script don't need to install TypeScript globally or in their project",
-    "build": "npx -p typescript tsc --build tsconfig.build.json",
+    "build": "tsc --build tsconfig.build.json",
     "clean": "git clean -dfqX",
     "install-with-npm-8.5": "npm i -g npm@^8.5.0 && npm i",
-    "postinstall": "npm run build",
     "prettier-check": "prettier --check .",
     "prettier-fix": "prettier --write .",
     "publish-changeset": "changeset publish",


### PR DESCRIPTION
Having a `postinstall` script that runs typescript has proven to be problematic for multiple reasons. The first one being that not all projects use `typescript`, which forced us to use `npx` in our `build` script. The next problem to surface is that `@types/node` doesn't exist in the install since it's a dev dependency of this repo. I don't consider adding `@types/node` to the dependencies of this package to be a good solution, so I'd prefer to just unwind the problem by not having a `postinstall` script at all.

This just means that developers in this repo should now run the `build` script after cloning and installing it.