### PR TITLE
Add prepare script

### DIFF
--- a/.changeset/many-ears-act.md
+++ b/.changeset/many-ears-act.md
@@ -1,0 +1,5 @@
+---
+'@apollo/datasource-rest': patch
+---
+
+Fix build process (again), ensure built directory exists before publish

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build": "tsc --build tsconfig.build.json",
     "clean": "git clean -dfqX",
     "install-with-npm-8.5": "npm i -g npm@^8.5.0 && npm i",
-    "prepare": "npm run build",
+    "prepack": "npm run build",
     "prettier-check": "prettier --check .",
     "prettier-fix": "prettier --write .",
     "publish-changeset": "changeset publish",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build": "tsc --build tsconfig.build.json",
     "clean": "git clean -dfqX",
     "install-with-npm-8.5": "npm i -g npm@^8.5.0 && npm i",
+    "prepare": "npm run build",
     "prettier-check": "prettier --check .",
     "prettier-fix": "prettier --write .",
     "publish-changeset": "changeset publish",


### PR DESCRIPTION
In #54, I removed the `postinstall` script. Our build/publish pipeline actually depended on the build that was a consequence of the `postinstall` script, so this broke publishing in that the build never occurred.

This commit adds a `prepare` script which runs the build prior to packing for publish.

So, I know `prepare` runs on a local `npm install`. That would be a good effect. However if it also runs on a transitive install, that would be a regression and we'd instead want `prepublishOnly` or `prepack`. Will experiment with CSB build first.