### PR TITLE
Strip undefined values from URL params; disallow some forms for `params`

### DIFF
--- a/.changeset/great-poems-share.md
+++ b/.changeset/great-poems-share.md
@@ -1,0 +1,15 @@
+---
+'@apollo/datasource-rest': major
+---
+
+When passing `params` as an object, parameters with `undefined` values are now skipped, like with `JSON.stringify`. So you can write:
+
+```ts
+getPost(query: string | undefined) {
+  return this.get('post', { params: { query } });
+}
+```
+
+and if `query` is not provided, the `query` parameter will be left off of the URL instead of given the value `undefined`.
+
+As part of this change, we've removed the ability to provide `params` in formats other than this kind of object or as an `URLSearchParams` object. Previously, we allowed every form of input that could be passed to `new URLSearchParams()`. If you were using one of the other forms (like a pre-serialized URL string or an array of two-element arrays), just pass it directly to `new URLSearchParams`; note that the feature of stripping `undefined` values will not occur in this case. For example, you can replace `this.get('post', { params: [['query', query]] })` with `this.get('post', { params: new URLSearchParams([['query', query]]) })`. (`URLSearchParams` is available in Node as a global.)


### PR DESCRIPTION
Being able to specify `params` as a single record object is very convenient, but it becomes inconvenient when some parameters are optional. Previously you could not use the record object syntax if a parameter is optional. Now you can use that syntax and we will strip undefined values, like `JSON.stringify`.

Previously we allowed all of the various forms of data that can be passed to `new URLSearchParams()` (and in fact just passed what we got directly to there). Implementing this undefined-stripping for all of the forms (like "arbitrary iterable object of two-element arrays") would be a lot of code copied from the DOM implementation, but *not* stripping undefined from the other forms would be inconsistent. So we change to *only* allow the record form (which is the only form that our docs show) plus providing `URLSearchParams` yourself; if you used one of the other forms you can just add a `new URLSearchParams()` to your code.

See the changeset entry for more details.

Fixes #24.