### PR TITLE
Preserve `body` on request object passed to `willSendRequest`; fix `string` and `Buffer` body handling

### DIFF
--- a/.changeset/cuddly-cars-sparkle.md
+++ b/.changeset/cuddly-cars-sparkle.md
@@ -10,8 +10,3 @@ object passed to the `willSendRequest` hook, it was always `undefined`.
 For consistency and typings reasons, the `path` argument is now the first
 argument to the `willSendRequest` hook, followed by the `AugmentedRequest`
 request object.
-
-Related to the regression mentioned above, `string` and `Buffer` bodies were no
-longer being included at all on the outgoing request since they were just
-ignored and never appended to the `body`. `string` and `Buffer` bodies are now
-passed through to the outgoing request (without being JSON stringified).

--- a/.changeset/cuddly-cars-sparkle.md
+++ b/.changeset/cuddly-cars-sparkle.md
@@ -1,0 +1,10 @@
+---
+'@apollo/datasource-rest': patch
+---
+
+The v4 update introduced multiple regressions w.r.t. the intermediary `modifiedRequest` object that was added.
+
+1. The `body` was no longer being added to the intermediary request object before calling `willSendRequest`
+2. `modifiedRequest.body` was never being set in the case that the incoming body was a `string` or `Buffer`
+
+This change resolves both by reverting to what we previously had in v3 (preserving the properties on the incoming request object). The types have been updated accordingly.

--- a/.changeset/cuddly-cars-sparkle.md
+++ b/.changeset/cuddly-cars-sparkle.md
@@ -1,10 +1,17 @@
 ---
-'@apollo/datasource-rest': patch
+'@apollo/datasource-rest': major
 ---
 
-The v4 update introduced multiple regressions w.r.t. the intermediary `modifiedRequest` object that was added.
+This change restores the full functionality of `willSendRequest` which
+previously existed in the v3 version of this package. The v4 change introduced a
+regression where the incoming request's `body` was no longer included in the
+object passed to the `willSendRequest` hook, it was always `undefined`.
 
-1. The `body` was no longer being added to the intermediary request object before calling `willSendRequest`
-2. `modifiedRequest.body` was never being set in the case that the incoming body was a `string` or `Buffer`
+For consistency and typings reasons, the `path` argument is now the first
+argument to the `willSendRequest` hook, followed by the `AugmentedRequest`
+request object.
 
-This change resolves both by reverting to what we previously had in v3 (preserving the properties on the incoming request object). The types have been updated accordingly.
+Related to the regression mentioned above, `string` and `Buffer` bodies were no
+longer being included at all on the outgoing request since they were just
+ignored and never appended to the `body`. `string` and `Buffer` bodies are now
+passed through to the outgoing request (without being JSON stringified).

--- a/.changeset/tidy-spoons-nail.md
+++ b/.changeset/tidy-spoons-nail.md
@@ -3,6 +3,6 @@
 ---
 
 `string` and `Buffer` bodies are now correctly included on the outgoing request.
-Due to a regression in v4, they were ignored and never appended to the `body`.
+Due to a regression in v4, they were ignored and never sent as the `body`.
 `string` and `Buffer` bodies are now passed through to the outgoing request
 (without being JSON stringified).

--- a/.changeset/tidy-spoons-nail.md
+++ b/.changeset/tidy-spoons-nail.md
@@ -1,0 +1,8 @@
+---
+'@apollo/datasource-rest': patch
+---
+
+`string` and `Buffer` bodies are now correctly included on the outgoing request.
+Due to a regression in v4, they were ignored and never appended to the `body`.
+`string` and `Buffer` bodies are now passed through to the outgoing request
+(without being JSON stringified).

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ This method is invoked immediately after `fetch` is called (or any of the
 convenience functions which call it like `.get()`). It's called with the `path`
 and `request` provided to `fetch`, with a guaranteed non-empty `headers` and
 `params` objects. If a `Promise` is returned from this method it will wait until
-the promise is completed to continue executing the request.
+the promise is completed to continue executing the request. See the
+[intercepting fetches](#intercepting-fetches) section for usage examples.
 
 ##### `cacheOptionsFor`
 Allows setting the `CacheOptions` to be used for each request/response in the HTTPCache. This is separate from the request-only cache. You can use this to set the TTL.

--- a/README.md
+++ b/README.md
@@ -105,7 +105,11 @@ By default, `RESTDatasource` uses the full request URL as the cache key. Overrid
 For example, you could use this to use header fields as part of the cache key. Even though we do validate header fields and don't serve responses from cache when they don't match, new responses overwrite old ones with different header fields.
 
 ##### `willSendRequest`
-This method is invoked just before the fetch call is made. If a `Promise` is returned from this method it will wait until the promise is completed to continue executing the request.
+This method is invoked immediately after `fetch` is called (or any of the
+convenience functions which call it like `.get()`). It's called with the `path`
+and `request` provided to `fetch`, with a guaranteed non-empty `headers` and
+`params` objects. If a `Promise` is returned from this method it will wait until
+the promise is completed to continue executing the request.
 
 ##### `cacheOptionsFor`
 Allows setting the `CacheOptions` to be used for each request/response in the HTTPCache. This is separate from the request-only cache. You can use this to set the TTL.
@@ -180,7 +184,7 @@ You can easily set a header on every request:
 
 ```javascript
 class PersonalizationAPI extends RESTDataSource {
-  willSendRequest(request) {
+  willSendRequest(path, request) {
     request.headers['authorization'] = this.context.token;
   }
 }
@@ -190,13 +194,13 @@ Or add a query parameter:
 
 ```javascript
 class PersonalizationAPI extends RESTDataSource {
-  willSendRequest(request) {
+  willSendRequest(path, request) {
     request.params.set('api_key', this.context.token);
   }
 }
 ```
 
-If you're using TypeScript, you can use the `RequestOptions` type to define the `willSendRequest` signature:
+If you're using TypeScript, you can use the `AugmentedRequest` type to define the `willSendRequest` signature:
 ```ts
 import { RESTDataSource, AugmentedRequest } from '@apollo/datasource-rest';
 
@@ -207,7 +211,7 @@ class PersonalizationAPI extends RESTDataSource {
     super();
   }
 
-  override willSendRequest(request: AugmentedRequest) {
+  override willSendRequest(_path: string, request: AugmentedRequest) {
     request.headers['authorization'] = this.token;
   }
 }
@@ -223,7 +227,7 @@ class PersonalizationAPI extends RESTDataSource {
     super();
   }
 
-  override async resolveURL(path: string) {
+  override async resolveURL(path: string, _request: AugmentedRequest) {
     if (!this.baseURL) {
       const addresses = await resolveSrv(path.split("/")[1] + ".service.consul");
       this.baseURL = addresses[0];

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ class PersonalizationAPI extends RESTDataSource {
 
 If you're using TypeScript, you can use the `RequestOptions` type to define the `willSendRequest` signature:
 ```ts
-import { RESTDataSource, WillSendRequestOptions } from '@apollo/datasource-rest';
+import { RESTDataSource, AugmentedRequest } from '@apollo/datasource-rest';
 
 class PersonalizationAPI extends RESTDataSource {
   override baseURL = 'https://personalization-api.example.com/';
@@ -207,7 +207,7 @@ class PersonalizationAPI extends RESTDataSource {
     super();
   }
 
-  override willSendRequest(request: WillSendRequestOptions) {
+  override willSendRequest(request: AugmentedRequest) {
     request.headers['authorization'] = this.token;
   }
 }

--- a/README.md
+++ b/README.md
@@ -105,12 +105,11 @@ By default, `RESTDatasource` uses the full request URL as the cache key. Overrid
 For example, you could use this to use header fields as part of the cache key. Even though we do validate header fields and don't serve responses from cache when they don't match, new responses overwrite old ones with different header fields.
 
 ##### `willSendRequest`
-This method is invoked immediately after `fetch` is called (or any of the
-convenience functions which call it like `.get()`). It's called with the `path`
-and `request` provided to `fetch`, with a guaranteed non-empty `headers` and
-`params` objects. If a `Promise` is returned from this method it will wait until
-the promise is completed to continue executing the request. See the
-[intercepting fetches](#intercepting-fetches) section for usage examples.
+This method is invoked at the beginning of processing each request. It's called
+with the `path` and `request` provided to `fetch`, with a guaranteed non-empty
+`headers` and `params` objects. If a `Promise` is returned from this method it
+will wait until the promise is completed to continue executing the request. See
+the [intercepting fetches](#intercepting-fetches) section for usage examples.
 
 ##### `cacheOptionsFor`
 Allows setting the `CacheOptions` to be used for each request/response in the HTTPCache. This is separate from the request-only cache. You can use this to set the TTL.

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -82,6 +82,7 @@ export abstract class RESTDataSource {
   }
 
   protected willSendRequest?(
+    path: string,
     requestOpts: AugmentedRequest,
   ): ValueOrPromise<void>;
 
@@ -221,7 +222,7 @@ export abstract class RESTDataSource {
     };
 
     if (this.willSendRequest) {
-      await this.willSendRequest(augmentedRequest);
+      await this.willSendRequest(path, augmentedRequest);
     }
 
     const url = await this.resolveURL(path, augmentedRequest);

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -41,12 +41,10 @@ export interface RequestWithBody extends Omit<RequestOptions, 'body'> {
 
 type DataSourceRequest = GetRequest | RequestWithBody;
 
+// While tempting, this union can't be reduced / factored out to just
+// Omit<WithRequired<GetRequest | RequestWithBody, 'headers'>, 'params'> & { params: URLSearchParams }
+// TS loses its ability to discriminate against the method (and its consequential `body` type)
 /**
- * While tempting, this union can't be reduced / factored out to just
- * Omit<WithRequired<GetRequest | RequestWithBody, 'headers'>, 'params'> & {
- * params: URLSearchParams } TS loses its ability to discriminate against the
- * method (and its consequential `body` type)
- *
  * This type is for convenience w.r.t. the `willSendRequest` and `resolveURL`
  * hooks to ensure that headers and params are always present, even if they're
  * empty.

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -39,7 +39,7 @@ export interface RequestWithBody extends Omit<RequestOptions, 'body'> {
   body?: FetcherRequestInit['body'] | object;
 }
 
-export type DataSourceRequest = GetRequest | RequestWithBody;
+type DataSourceRequest = GetRequest | RequestWithBody;
 
 export type AugmentedRequest = (
   | Omit<WithRequired<GetRequest, 'headers'>, 'params'>
@@ -79,7 +79,7 @@ export abstract class RESTDataSource {
   }
 
   protected willSendRequest?(
-    requestOpts: DataSourceRequest,
+    requestOpts: AugmentedRequest,
   ): ValueOrPromise<void>;
 
   protected resolveURL(

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -236,6 +236,7 @@ export abstract class RESTDataSource {
     // `string`, `Buffer`, and `undefined` are passed through up above as-is.
     if (
       augmentedRequest.body != null &&
+      !(augmentedRequest.body instanceof Buffer) &&
       (augmentedRequest.body.constructor === Object ||
         Array.isArray(augmentedRequest.body) ||
         ((augmentedRequest.body as any).toJSON &&

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -236,6 +236,8 @@ export abstract class RESTDataSource {
       } else if (!modifiedRequest.headers['content-type']) {
         modifiedRequest.headers['content-type'] = 'application/json';
       }
+    } else if (typeof request.body === 'string') {
+      modifiedRequest.body = request.body;
     }
 
     if (this.willSendRequest) {

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -41,6 +41,9 @@ export interface RequestWithBody extends Omit<RequestOptions, 'body'> {
 
 type DataSourceRequest = GetRequest | RequestWithBody;
 
+// While tempting, this union can't be reduced / factored out to just
+// Omit<WithRequired<GetRequest | RequestWithBody, 'headers'>, 'params'> & { params: URLSearchParams }
+// TS loses its ability to discriminate against the method (and its consequential `body` type)
 export type AugmentedRequest = (
   | Omit<WithRequired<GetRequest, 'headers'>, 'params'>
   | Omit<WithRequired<RequestWithBody, 'headers'>, 'params'>

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -29,15 +29,6 @@ export type RequestOptions = FetcherRequestInit & {
       ) => CacheOptions | undefined);
 };
 
-type ModifiedRequest = Omit<
-  WithRequired<RequestOptions, 'headers'>,
-  'params'
-> & {
-  params: URLSearchParams;
-};
-
-export type WillSendRequestOptions = ModifiedRequest;
-
 export interface GetRequest extends RequestOptions {
   method?: 'GET';
   body?: never;
@@ -48,7 +39,14 @@ export interface RequestWithBody extends Omit<RequestOptions, 'body'> {
   body?: FetcherRequestInit['body'] | object;
 }
 
-type DataSourceRequest = GetRequest | RequestWithBody;
+export type DataSourceRequest = GetRequest | RequestWithBody;
+
+export type AugmentedRequest = (
+  | Omit<WithRequired<GetRequest, 'headers'>, 'params'>
+  | Omit<WithRequired<RequestWithBody, 'headers'>, 'params'>
+) & {
+  params: URLSearchParams;
+};
 
 export interface CacheOptions {
   ttl?: number;
@@ -81,7 +79,7 @@ export abstract class RESTDataSource {
   }
 
   protected willSendRequest?(
-    requestOpts: WillSendRequestOptions,
+    requestOpts: DataSourceRequest,
   ): ValueOrPromise<void>;
 
   protected resolveURL(
@@ -207,65 +205,66 @@ export abstract class RESTDataSource {
 
   private async fetch<TResult>(
     path: string,
-    request: DataSourceRequest,
+    incomingRequest: DataSourceRequest,
   ): Promise<TResult> {
-    const modifiedRequest: ModifiedRequest = {
-      ...request,
+    const augmentedRequest: AugmentedRequest = {
+      ...incomingRequest,
       // guarantee params and headers objects before calling `willSendRequest` for convenience
       params:
-        request.params instanceof URLSearchParams
-          ? request.params
-          : this.urlSearchParamsFromRecord(request.params),
-      headers: request.headers ?? Object.create(null),
-      body: undefined,
+        incomingRequest.params instanceof URLSearchParams
+          ? incomingRequest.params
+          : this.urlSearchParamsFromRecord(incomingRequest.params),
+      headers: incomingRequest.headers ?? Object.create(null),
     };
 
-    // We accept arbitrary objects and arrays as body and serialize them as JSON
-    if (
-      request.body !== undefined &&
-      request.body !== null &&
-      (request.body.constructor === Object ||
-        Array.isArray(request.body) ||
-        ((request.body as any).toJSON &&
-          typeof (request.body as any).toJSON === 'function'))
-    ) {
-      modifiedRequest.body = JSON.stringify(request.body);
-      // If Content-Type header has not been previously set, set to application/json
-      if (!modifiedRequest.headers) {
-        modifiedRequest.headers = { 'content-type': 'application/json' };
-      } else if (!modifiedRequest.headers['content-type']) {
-        modifiedRequest.headers['content-type'] = 'application/json';
-      }
-    } else if (typeof request.body === 'string') {
-      modifiedRequest.body = request.body;
-    }
-
     if (this.willSendRequest) {
-      await this.willSendRequest(modifiedRequest);
+      await this.willSendRequest(augmentedRequest);
     }
 
-    const url = await this.resolveURL(path, modifiedRequest);
+    // We accept arbitrary objects and arrays as body and serialize them as JSON.
+    // `string`, `Buffer`, and `undefined` are passed through up above as-is.
+    if (
+      augmentedRequest.body != null &&
+      (augmentedRequest.body.constructor === Object ||
+        Array.isArray(augmentedRequest.body) ||
+        ((augmentedRequest.body as any).toJSON &&
+          typeof (augmentedRequest.body as any).toJSON === 'function'))
+    ) {
+      augmentedRequest.body = JSON.stringify(augmentedRequest.body);
+      // If Content-Type header has not been previously set, set to application/json
+      if (!augmentedRequest.headers) {
+        augmentedRequest.headers = { 'content-type': 'application/json' };
+      } else if (!augmentedRequest.headers['content-type']) {
+        augmentedRequest.headers['content-type'] = 'application/json';
+      }
+    }
+
+    // At this point we know the `body` is a `string`, `Buffer`, or `undefined`
+    // (not possibly an `object`).
+    const outgoingRequest = <RequestOptions>augmentedRequest;
+
+    const url = await this.resolveURL(path, outgoingRequest);
 
     // Append params to existing params in the path
-    for (const [name, value] of modifiedRequest.params as URLSearchParams) {
+    for (const [name, value] of outgoingRequest.params as URLSearchParams) {
       url.searchParams.append(name, value);
     }
 
-    const cacheKey = this.cacheKeyFor(url, modifiedRequest);
+    const cacheKey = this.cacheKeyFor(url, outgoingRequest);
 
     const performRequest = async () => {
-      return this.trace(url, modifiedRequest, async () => {
-        const cacheOptions = modifiedRequest.cacheOptions
-          ? modifiedRequest.cacheOptions
+      return this.trace(url, outgoingRequest, async () => {
+        const cacheOptions = outgoingRequest.cacheOptions
+          ? outgoingRequest.cacheOptions
           : this.cacheOptionsFor?.bind(this);
         try {
-          const response = await this.httpCache.fetch(url, modifiedRequest, {
+          const response = await this.httpCache.fetch(url, outgoingRequest, {
             cacheKey,
             cacheOptions,
           });
-          return await this.didReceiveResponse(response, modifiedRequest);
+          return await this.didReceiveResponse(response, outgoingRequest);
         } catch (error) {
-          this.didEncounterError(error as Error, modifiedRequest);
+          this.didEncounterError(error as Error, outgoingRequest);
         }
       });
     };
@@ -273,7 +272,7 @@ export abstract class RESTDataSource {
     // Cache GET requests based on the calculated cache key
     // Disabling the request cache does not disable the response cache
     if (this.memoizeGetRequests) {
-      if (request.method === 'GET') {
+      if (outgoingRequest.method === 'GET') {
         let promise = this.memoizedResults.get(cacheKey);
         if (promise) return promise;
 

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -252,7 +252,7 @@ export abstract class RESTDataSource {
 
     // At this point we know the `body` is a `string`, `Buffer`, or `undefined`
     // (not possibly an `object`).
-    const outgoingRequest = <RequestOptions>augmentedRequest;
+    const outgoingRequest = augmentedRequest as RequestOptions;
 
     const cacheKey = this.cacheKeyFor(url, outgoingRequest);
 

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -41,9 +41,16 @@ export interface RequestWithBody extends Omit<RequestOptions, 'body'> {
 
 type DataSourceRequest = GetRequest | RequestWithBody;
 
-// While tempting, this union can't be reduced / factored out to just
-// Omit<WithRequired<GetRequest | RequestWithBody, 'headers'>, 'params'> & { params: URLSearchParams }
-// TS loses its ability to discriminate against the method (and its consequential `body` type)
+/**
+ * While tempting, this union can't be reduced / factored out to just
+ * Omit<WithRequired<GetRequest | RequestWithBody, 'headers'>, 'params'> & {
+ * params: URLSearchParams } TS loses its ability to discriminate against the
+ * method (and its consequential `body` type)
+ *
+ * This type is for convenience w.r.t. the `willSendRequest` and `resolveURL`
+ * hooks to ensure that headers and params are always present, even if they're
+ * empty.
+ */
 export type AugmentedRequest = (
   | Omit<WithRequired<GetRequest, 'headers'>, 'params'>
   | Omit<WithRequired<RequestWithBody, 'headers'>, 'params'>

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -113,7 +113,7 @@ describe('RESTDataSource', () => {
 
     it('allows resolving a base URL asynchronously', async () => {
       const dataSource = new (class extends RESTDataSource {
-        override async resolveURL(path: string, request: RequestOptions) {
+        override async resolveURL(path: string, request: AugmentedRequest) {
           if (!this.baseURL) {
             this.baseURL = 'https://api.example.com';
           }
@@ -916,7 +916,7 @@ describe('RESTDataSource', () => {
       });
 
       describe('resolveURL', () => {
-        it('sees the same request body used by outgoing fetch', async () => {
+        it('sees the same request body as provided by the caller', async () => {
           const dataSource = new (class extends RESTDataSource {
             override baseURL = apiUrl;
 
@@ -924,18 +924,10 @@ describe('RESTDataSource', () => {
               return this.post(`foo/${id}`, { body: foo });
             }
 
-            override resolveURL(path: string, requestOpts: RequestOptions) {
-              expect(requestOpts).toMatchInlineSnapshot(`
+            override resolveURL(path: string, requestOpts: AugmentedRequest) {
+              expect(requestOpts.body).toMatchInlineSnapshot(`
                 {
-                  "body": "{"name":"blah"}",
-                  "headers": {
-                    "content-type": "application/json",
-                  },
-                  "method": "POST",
-                  "params": URLSearchParams {
-                    Symbol(query): [],
-                    Symbol(context): null,
-                  },
+                  "name": "blah",
                 }
               `);
               return super.resolveURL(path, requestOpts);

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -894,7 +894,7 @@ describe('RESTDataSource', () => {
         const obj = { foo: 'bar' };
         const str = 'foo=bar';
         const buffer = Buffer.from(str);
-        
+
         it.each([
           ['object', obj, obj],
           ['string', str, str],
@@ -938,7 +938,7 @@ describe('RESTDataSource', () => {
 
           nock(apiUrl).post('/foo/1', obj).reply(200);
           await dataSource.updateFoo(1, obj);
-        })
+        });
       });
 
       describe('resolveURL', () => {

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -342,6 +342,27 @@ describe('RESTDataSource', () => {
       await dataSource.postFoo(form);
     });
 
+    it('does not serialize (but does include) string request bodies', async () => {
+      const dataSource = new (class extends RESTDataSource {
+        override baseURL = 'https://api.example.com';
+
+        updateFoo(id: number, urlEncodedFoo: string) {
+          return this.post(`foo/${id}`, {
+            headers: { 'content-type': 'application/x-www-urlencoded' },
+            body: urlEncodedFoo,
+          });
+        }
+      })();
+
+      nock(apiUrl)
+        .post('/foo/1', (body) => {
+          return body === "id=1&name=bar";
+        })
+        .reply(200, 'ok', { 'content-type': 'text/plain' });
+
+      await dataSource.updateFoo(1, 'id=1&name=bar');
+    });
+
     describe('all methods', () => {
       const dataSource = new (class extends RESTDataSource {
         override baseURL = 'https://api.example.com';

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -356,7 +356,7 @@ describe('RESTDataSource', () => {
 
       nock(apiUrl)
         .post('/foo/1', (body) => {
-          return body === "id=1&name=bar";
+          return body === 'id=1&name=bar';
         })
         .reply(200, 'ok', { 'content-type': 'text/plain' });
 

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -360,6 +360,7 @@ describe('RESTDataSource', () => {
     });
 
     it('does not serialize (but does include) `Buffer` request bodies', async () => {
+      const expectedData = 'id=1&name=bar';
       const dataSource = new (class extends RESTDataSource {
         override baseURL = 'https://api.example.com';
 
@@ -373,11 +374,11 @@ describe('RESTDataSource', () => {
 
       nock(apiUrl)
         .post('/foo/1', (body) => {
-          return Buffer.from(body.data).toString() === 'id=1&name=bar';
+          return body === expectedData;
         })
         .reply(200, 'ok', { 'content-type': 'text/plain' });
 
-      await dataSource.updateFoo(1, Buffer.from('id=1&name=bar'));
+      await dataSource.updateFoo(1, Buffer.from(expectedData));
     });
 
     describe('all methods', () => {
@@ -898,7 +899,7 @@ describe('RESTDataSource', () => {
         it.each([
           ['object', obj, obj],
           ['string', str, str],
-          ['buffer', buffer, buffer.toJSON()],
+          ['buffer', buffer, str],
         ])(`can set the body to a %s`, async (_, body, expected) => {
           const dataSource = new (class extends RESTDataSource {
             override baseURL = apiUrl;

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -866,8 +866,10 @@ describe('RESTDataSource', () => {
             ) {
               expect(requestOpts).toMatchInlineSnapshot(`
                 {
-                  "body": undefined,
-                  "headers": {},
+                  "body": "{"name":"blah"}",
+                  "headers": {
+                    "content-type": "application/json",
+                  },
                   "method": "POST",
                   "params": URLSearchParams {
                     Symbol(query): [],
@@ -875,6 +877,40 @@ describe('RESTDataSource', () => {
                   },
                 }
               `);
+            }
+          })();
+
+          nock(apiUrl)
+            .post('/foo/1', JSON.stringify({ name: 'blah' }))
+            .reply(200);
+          await dataSource.updateFoo(1, { name: 'blah' });
+        });
+      });
+
+      describe('resolveURL', () => {
+        it('sees the same request body used by outgoing fetch', async () => {
+          const dataSource = new (class extends RESTDataSource {
+            override baseURL = apiUrl;
+
+            updateFoo(id: number, foo: { name: string }) {
+              return this.post(`foo/${id}`, { body: foo });
+            }
+
+            override resolveURL(path: string, requestOpts: RequestOptions) {
+              expect(requestOpts).toMatchInlineSnapshot(`
+                {
+                  "body": "{"name":"blah"}",
+                  "headers": {
+                    "content-type": "application/json",
+                  },
+                  "method": "POST",
+                  "params": URLSearchParams {
+                    Symbol(query): [],
+                    Symbol(context): null,
+                  },
+                }
+              `);
+              return super.resolveURL(path, requestOpts);
             }
           })();
 

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -3,7 +3,6 @@ import {
   AuthenticationError,
   CacheOptions,
   DataSourceConfig,
-  DataSourceRequest,
   ForbiddenError,
   RequestOptions,
   RESTDataSource,
@@ -216,7 +215,7 @@ describe('RESTDataSource', () => {
       const dataSource = new (class extends RESTDataSource {
         override baseURL = 'https://api.example.com';
 
-        override willSendRequest(request: DataSourceRequest) {
+        override willSendRequest(request: AugmentedRequest) {
           request.headers = { ...request.headers, credentials: 'include' };
         }
 
@@ -900,7 +899,7 @@ describe('RESTDataSource', () => {
               return this.post(`foo/${id}`, { body: foo });
             }
 
-            override async willSendRequest(requestOpts: DataSourceRequest) {
+            override async willSendRequest(requestOpts: AugmentedRequest) {
               expect(requestOpts.body).toMatchInlineSnapshot(`
                 {
                   "name": "blah",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export {
   RESTDataSource,
   RequestOptions,
-  WillSendRequestOptions,
+  AugmentedRequest,
 } from './RESTDataSource';


### PR DESCRIPTION
The v4 update introduced multiple regressions w.r.t. the `modifiedRequest` object that I added.
1) `body` was no longer being added to the intermediary request object before calling `willSendRequest`
2) `modifiedRequest.body` was never being set in the case that the incoming body was a `string` or `Buffer`

This change resolves both by reverting to what we previously had in v3 (preserving the properties on the incoming request object). The types had to be updated accordingly. Due to how `path` is now handled in v4, the `willSendRequest` signature is now `(path, request)`.

I'm a bit disappointed in the complexity of the typings in here. We make multiple incremental refinements to the request object:
1) first by ensuring headers/params, effectively adding one level of `WithRequired` to our incoming request type
2) second by refining the `body` type to drop the `object` from the union since those are stringified

Our hooks expose the request object that we're building at various points in the construction of the request so these types are part of the public API - kind of confusing and difficult to name in ways that are simple and sensible.
i.e. `RequestWithHeadersAndParams` and `RequestWithHeadersAndParamsAndBodyIsCompatibleWithFetch`

Fixes #83