### PR TITLE
Remove `didReceiveResponse` hook

### DIFF
--- a/.changeset/khaki-cars-remember.md
+++ b/.changeset/khaki-cars-remember.md
@@ -4,8 +4,17 @@
 
 Reduce responsibility of `didReceiveResponse` hook
 
-The naming of this hook is deceiving; if this hook is overridden it becomes responsible for returning the parsed body. It was originally introduced in https://github.com/apollographql/apollo-server/issues/1324, where the author claims they implemented it due to lack of access to the complete response (headers) in the fetch methods (get, post, ...). This approach isn't a type safe way to acoomplish this.
+The naming of this hook is deceiving; if this hook is overridden it becomes
+responsible for returning the parsed body. It was originally introduced in
+https://github.com/apollographql/apollo-server/issues/1324, where the author
+claims they implemented it due to lack of access to the complete response
+(headers) in the fetch methods (get, post, ...). This approach isn't a type safe
+way to acoomplish this.
 
-This hook is now just an observability hook which receives a clone of the response and the request that was sent.
+This hook is now just an observability hook which receives a clone of the
+response and the request that was sent.
 
-A change following this will introduce the ability to fetch a complete response (headers included) aside from the provided fetch methods which only return a body, which will reinstate the functionality that the author of this hook had originally intended.
+A change following this will introduce the ability to fetch a complete response
+(headers included) aside from the provided fetch methods which only return a
+body, which will reinstate the functionality that the author of this hook had
+originally intended.

--- a/.changeset/khaki-cars-remember.md
+++ b/.changeset/khaki-cars-remember.md
@@ -1,0 +1,11 @@
+---
+'@apollo/datasource-rest': major
+---
+
+Reduce responsibility of `didReceiveResponse` hook
+
+The naming of this hook is deceiving; if this hook is overridden it becomes responsible for returning the parsed body. It was originally introduced in https://github.com/apollographql/apollo-server/issues/1324, where the author claims they implemented it due to lack of access to the complete response (headers) in the fetch methods (get, post, ...). This approach isn't a type safe way to acoomplish this.
+
+This hook is now just an observability hook which receives a clone of the response and the request that was sent.
+
+A change following this will introduce the ability to fetch a complete response (headers included) aside from the provided fetch methods which only return a body, which will reinstate the functionality that the author of this hook had originally intended.

--- a/.changeset/khaki-cars-remember.md
+++ b/.changeset/khaki-cars-remember.md
@@ -2,19 +2,19 @@
 '@apollo/datasource-rest': major
 ---
 
-Reduce responsibility of `didReceiveResponse` hook
+Remove `didReceiveResponse` hook
 
 The naming of this hook is deceiving; if this hook is overridden it becomes
-responsible for returning the parsed body. It was originally introduced in
+responsible for returning the parsed body and handling errors if they occur. It
+was originally introduced in
 https://github.com/apollographql/apollo-server/issues/1324, where the author
-claims they implemented it due to lack of access to the complete response
-(headers) in the fetch methods (get, post, ...). This approach isn't a type safe
-way to acoomplish this.
+implemented it due to lack of access to the complete response (headers) in the
+fetch methods (get, post, ...). This approach isn't a type safe way to
+accomplish this and places the burden of body parsing and error handling on the
+user.
 
-This hook is now just an observability hook which receives a clone of the
-response and the request that was sent.
-
-A change following this will introduce the ability to fetch a complete response
-(headers included) aside from the provided fetch methods which only return a
-body, which will reinstate the functionality that the author of this hook had
-originally intended.
+Removing this hook is a prerequisite to a subsequent change that will introduce
+the ability to fetch a complete response (headers included) aside from the
+provided fetch methods which only return a body. This change will reinstate the
+functionality that the author of this hook had originally intended in a more
+direct manner.

--- a/README.md
+++ b/README.md
@@ -154,11 +154,6 @@ override cacheOptionsFor() {
 }
 ```
 
-##### `didReceiveResponse`
-By default, this method checks if the response was returned successfully and parses the response into the result object. If the response had an error, it detects which type of HTTP error and throws the error result.
-
-If you override this behavior, be sure to implement the proper error handling.
-
 ##### `didEncounterError`
 By default, this method just throws the `error` it was given. If you override this method, you can choose to either perform some additional logic and still throw, or to swallow the error by not throwing the error result.
 

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -176,16 +176,10 @@ export abstract class RESTDataSource {
     request: FetcherRequestInit,
   ): CacheOptions | undefined;
 
-  protected async didReceiveResponse<TResult = any>(
+  protected async didReceiveResponse?(
     response: FetcherResponse,
-    _request: RequestOptions,
-  ): Promise<TResult> {
-    if (response.ok) {
-      return this.parseBody(response) as any as Promise<TResult>;
-    } else {
-      throw await this.errorFromResponse(response);
-    }
-  }
+    request: RequestOptions,
+  ): Promise<void>;
 
   protected didEncounterError(error: Error, _request: RequestOptions) {
     throw error;
@@ -353,9 +347,20 @@ export abstract class RESTDataSource {
             cacheKey,
             cacheOptions,
           });
-          return await this.didReceiveResponse(response, outgoingRequest);
+
+
+          if (this.didReceiveResponse) {
+            await this.didReceiveResponse(response.clone(), outgoingRequest);
+          }
+
+          if (response.ok) {
+            return (await this.parseBody(response)) as TResult;
+          } else {
+            throw await this.errorFromResponse(response);
+          }
         } catch (error) {
           this.didEncounterError(error as Error, outgoingRequest);
+          throw error;
         }
       });
     };

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -348,7 +348,6 @@ export abstract class RESTDataSource {
             cacheOptions,
           });
 
-
           if (this.didReceiveResponse) {
             await this.didReceiveResponse(response.clone(), outgoingRequest);
           }

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -176,11 +176,6 @@ export abstract class RESTDataSource {
     request: FetcherRequestInit,
   ): CacheOptions | undefined;
 
-  protected async didReceiveResponse?(
-    response: FetcherResponse,
-    request: RequestOptions,
-  ): Promise<void>;
-
   protected didEncounterError(error: Error, _request: RequestOptions) {
     throw error;
   }
@@ -347,10 +342,6 @@ export abstract class RESTDataSource {
             cacheKey,
             cacheOptions,
           });
-
-          if (this.didReceiveResponse) {
-            await this.didReceiveResponse(response.clone(), outgoingRequest);
-          }
 
           if (response.ok) {
             return (await this.parseBody(response)) as TResult;

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -13,7 +13,6 @@ import FormData from 'form-data';
 import { GraphQLError } from 'graphql';
 import nock from 'nock';
 import { nockAfterEach, nockBeforeEach } from './nockAssertions';
-import type { FetcherResponse } from '@apollo/utils.fetcher';
 
 const apiUrl = 'https://api.example.com';
 

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -1146,47 +1146,6 @@ describe('RESTDataSource', () => {
           expect(calls).toBe(1);
         });
       });
-
-      describe('didReceiveResponse', () => {
-        it('is called if implemented', async () => {
-          const didReceiveResponseMock = jest.fn(async () => {});
-          const dataSource = new (class extends RESTDataSource {
-            override baseURL = apiUrl;
-
-            getFoo(id: number) {
-              return this.get(`foo/${id}`);
-            }
-
-            override didReceiveResponse = didReceiveResponseMock;
-          })();
-
-          nock(apiUrl).get('/foo/1').reply(200, { name: 'bar' });
-          await dataSource.getFoo(1);
-          expect(didReceiveResponseMock).toHaveBeenCalledTimes(1);
-        });
-
-        it('is ok to consume the body on the response', async () => {
-          let observedBody;
-          const dataSource = new (class extends RESTDataSource {
-            override baseURL = apiUrl;
-
-            getFoo(id: number) {
-              return this.get(`foo/${id}`);
-            }
-
-            override async didReceiveResponse(
-              response: FetcherResponse,
-              _outgoingRequest: RequestOptions,
-            ) {
-              observedBody = await response.json();
-            }
-          })();
-
-          nock(apiUrl).get('/foo/1').reply(200, { name: 'bar' });
-          await dataSource.getFoo(1);
-          expect(observedBody).toEqual({ name: 'bar' });
-        });
-      });
     });
   });
 });


### PR DESCRIPTION
The naming of this hook is deceiving; if this hook is overridden it becomes
responsible for returning the parsed body and handling errors if they occur. It
was originally introduced in
https://github.com/apollographql/apollo-server/issues/1324, where the author
implemented it due to lack of access to the complete response (headers) in the
fetch methods (get, post, ...). This approach isn't a type safe way to
accomplish this and places the burden of body parsing and error handling on the
user.

Removing this hook is a prerequisite to a subsequent change that will introduce
the ability to fetch a complete response (headers included) aside from the
provided fetch methods which only return a body. This change will reinstate the
functionality that the author of this hook had originally intended in a more
direct manner.

We can consider reinstating this hook or something similar in the future with well-documented and use-case-driven semantics. Without knowing other reasons for why this hook should exist (aside from mentioned issue, which will be addressed with an alternative approach), trying to guess what this hook should do or mean is a bit pointless.