### PR TITLE
Allow specifying `cacheKey` explicitly in request options

### DIFF
--- a/.changeset/beige-teachers-think.md
+++ b/.changeset/beige-teachers-think.md
@@ -1,0 +1,5 @@
+---
+'@apollo/datasource-rest': minor
+---
+
+Allow specifying the cache key directly as a `cacheKey` option in the request options. This is read by the default implementation of `cacheKeyFor` (which is still called).

--- a/.changeset/light-dolls-design.md
+++ b/.changeset/light-dolls-design.md
@@ -1,0 +1,5 @@
+---
+'@apollo/datasource-rest': minor
+---
+
+Allow specifying the options passed to `new CachePolicy()` via a `httpCacheSemanticsCachePolicyOptions` option in the request options.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If a resource's path starts with something that looks like an URL because it con
 #### Methods
 
 ##### `cacheKeyFor`
-By default, `RESTDatasource` uses the full request URL as a cache key when saving information about the request to the `KeyValueCache`. Override this method to remove query parameters or compute a custom cache key.
+By default, `RESTDatasource` uses the `cacheKey` option from the request as the cache key, or the full request URL otherwise when saving information about the request to the `KeyValueCache`. Override this method to remove query parameters or compute a custom cache key.
 
 For example, you could use this to use header fields or the HTTP method as part of the cache key. Even though we do validate header fields and don't serve responses from cache when they don't match, new responses overwrite old ones with different header fields. (For the HTTP method, this might be a positive thing, as you may want a `POST /foo` request to stop a previously cached `GET /foo` from being returned.)
 
@@ -207,7 +207,7 @@ class MoviesAPI extends RESTDataSource {
 }
 ```
 
-All of the HTTP helper functions (`get`, `put`, `post`, `patch`, and `delete`) accept a second parameter for setting the `body`, `headers`, `params`, and `cacheOptions`.
+All of the HTTP helper functions (`get`, `put`, `post`, `patch`, and `delete`) accept a second parameter for setting the `body`, `headers`, `params`, `cacheKey`, and `cacheOptions`.
 
 ### Intercepting fetches
 

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -793,7 +793,7 @@ describe('RESTDataSource', () => {
 
         nock(apiUrl).get('/foo/1').reply(200);
 
-        await Promise.all([dataSource.getFoo(1), dataSource.getFoo(1)]);
+        await Promise.all([dataSource.getFoo(1), dataSource.getFoo(2)]);
       });
 
       it('allows specifying a custom cache key via cacheKey used for HTTP-header-sensitive cache', async () => {
@@ -815,7 +815,7 @@ describe('RESTDataSource', () => {
           .reply(200, '{}', { 'cache-control': 'max-age=60' });
 
         await dataSource.getFoo(1);
-        await dataSource.getFoo(1);
+        await dataSource.getFoo(2);
       });
 
       it('allows disabling deduplication', async () => {


### PR DESCRIPTION
Also add a changeset for #112 that was merged today.

Fixes #65.