### PR TITLE
New throwIfResponseIsError hook

### DIFF
--- a/.changeset/empty-yaks-juggle.md
+++ b/.changeset/empty-yaks-juggle.md
@@ -1,0 +1,5 @@
+---
+'@apollo/datasource-rest': major
+---
+
+The `errorFromResponse` method now receives an options object with `url`, `request`, `response`, and `parsedBody` rather than just a response, and the body has already been parsed.

--- a/.changeset/silly-apricots-exercise.md
+++ b/.changeset/silly-apricots-exercise.md
@@ -1,0 +1,5 @@
+---
+'@apollo/datasource-rest': minor
+---
+
+New `throwIfResponseIsError` hook allows you to control whether a response should be returned or thrown as an error. Partially replaces the removed `didReceiveResponse` hook.


### PR DESCRIPTION
We previously removed `didReceiveResponse` which let you override the main "is it an error or not" logic. This restores it in an error-specific way. This means you can throw errors even on 200s if you want (or vice versa).

This also changes the `errorFromResponse` hook to take options instead of a single argument, in case you want the error to reflect more data.

One negative change is you can no longer prevent `parseBody` from being called, though you can always override `parseBody` to do less.

Fixes #32.