### PR TITLE
New `requestDeduplication` field on `DataSourceFetchResult`

### DIFF
--- a/.changeset/wet-ligers-tap.md
+++ b/.changeset/wet-ligers-tap.md
@@ -7,3 +7,5 @@ Add public `fetch` method
 Users previously had no well-defined way to access the complete response (i.e. for header inspection). The public API of HTTP helper methods only returned the parsed response body. A `didReceiveResponse` hook existed as an attempt to solve this, but its semantics weren't well-defined, nor was it a type safe approach to solving the problem.
 
 The new `fetch` method allows users to "bypass" the convenience of the HTTP helpers in order to construct their own full request and inspect the complete response themselves.
+
+The `DataSourceFetchResult` type returned by this method also contains other useful information, like a `requestDeduplication` field containing the request's deduplication policy and whether it was deduplicated against a previous request.


### PR DESCRIPTION
This field is returned if you call `fetch` instead of `get` (etc) and it tells you what the deduplication policy was and if it matched.

Also allow `this.fetch` to be called with only one argument (because we previously made `method` optional).

Part of #41 (which also requests adding information on the other cache's status).