### PR TITLE
Move cacheWritePromise onto a sub-field of DataSourceFetchResult

### DIFF
--- a/.changeset/sixty-eels-taste.md
+++ b/.changeset/sixty-eels-taste.md
@@ -2,4 +2,4 @@
 '@apollo/datasource-rest': major
 ---
 
-We now write to the shared HTTP-header-sensitive cache in the background rather than before the fetch resolves. By default, errors talking to the cache are logged with `console.log`; override `catchCacheWritePromiseErrors` to customize. If you call `fetch()`, the result object has a `cacheWritePromise` field that you can `await` if you want to know when the cache write ends.
+We now write to the shared HTTP-header-sensitive cache in the background rather than before the fetch resolves. By default, errors talking to the cache are logged with `console.log`; override `catchCacheWritePromiseErrors` to customize. If you call `fetch()`, the result object has a `httpCache.cacheWritePromise` field that you can `await` if you want to know when the cache write ends.

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -109,12 +109,16 @@ export interface RequestDeduplicationResult {
   policy: RequestDeduplicationPolicy;
   deduplicatedAgainstPreviousRequest: boolean;
 }
+
+export interface HTTPCacheResult {
+  // This is primarily returned so that tests can be deterministic.
+  cacheWritePromise: Promise<void> | undefined;
+}
 export interface DataSourceFetchResult<TResult> {
   parsedBody: TResult;
   response: FetcherResponse;
   requestDeduplication: RequestDeduplicationResult;
-  // This is primarily returned so that tests can be deterministic.
-  cacheWritePromise: Promise<void> | undefined;
+  httpCache: HTTPCacheResult;
 }
 
 // RESTDataSource has two layers of caching. The first layer is purely in-memory
@@ -501,7 +505,9 @@ export abstract class RESTDataSource {
           return {
             parsedBody: parsedBody as any as TResult,
             response,
-            cacheWritePromise,
+            httpCache: {
+              cacheWritePromise,
+            },
           };
         } catch (error) {
           this.didEncounterError(error as Error, outgoingRequest);


### PR DESCRIPTION
This gives us an appropriate place to put the data desired by #41.

Also makes RESTDataSource tests actually wait on the cache writes (perhaps they were brittle before).