### PR TITLE
Fix incorrectly typed parameter in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class MoviesAPI extends RESTDataSource {
   async getMostViewedMovies(limit = 10) {
     const data = await this.get('movies', {
       params: {
-        per_page: limit,
+        per_page: limit.toString(), // all params entries should be strings
         order_by: 'most_viewed',
       },
     });


### PR DESCRIPTION
Related: #131.

Some discussion over there about extending / improving the API a bit, but this addresses an actual TS error in our docs.