### PR TITLE
Add docs for `didReceiveResponse` replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,12 +120,10 @@ At a higher level, the most notable changes include:
       path: string,
       incomingRequest: DataSourceRequest = {}
     ) {
-      return super
-        .fetch<TResult>(path, incomingRequest)
-        .then(({ parsedBody, response }) => {
-          // log or update your response object here
-          return { parsedBody, response };
-        });
+      const result = await super.fetch(path, incomingRequest);
+      // Log or update here; you have access to `result.parsedBody` and `result.response`.
+      // Return the `result` object when you're finished.
+      return result;
     }
   }
   ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,29 @@ At a higher level, the most notable changes include:
   functionality that the author of this hook had originally intended in a more
   direct manner.
 
+  You reasonably may have used this hook for things like observability and logging,
+  updating response headers, or mutating the response object in some other way. If
+  so, you can now override the public `fetch` method like so:
+  
+  ```ts
+  class MyDataSource extends RESTDataSource {
+    override async fetch<TResult>(
+      path: string,
+      incomingRequest: DataSourceRequest = {}
+    ) {
+      return super
+        .fetch<TResult>(path, incomingRequest)
+        .then(({ parsedBody, response }) => {
+          // log or update your response object here
+          return { parsedBody, response };
+        });
+    }
+  }
+  ```
+
+  All of the convenience http methods (`get()`, `post()`, etc.) call this `fetch` function, so
+  changes here will apply to every request that your datasource makes.
+
 - [#95](https://github.com/apollographql/datasource-rest/pull/95) [`c59b82f`](https://github.com/apollographql/datasource-rest/commit/c59b82fd7bfd90cac59fe10d65b3aa23658354c1) Thanks [@glasser](https://github.com/glasser)! - Simplify interpretation of `this.baseURL` so it works exactly like links in a web browser.
 
   If you set `this.baseURL` to an URL with a non-empty path component, this may change the URL that your methods talk to. Specifically:

--- a/README.md
+++ b/README.md
@@ -313,6 +313,32 @@ class PersonalizationAPI extends RESTDataSource {
 }
 ```
 
+### Processing Responses
+
+> Looking for `didReceiveResponse`? This section is probably interesting to you.
+
+You might need to read or mutate the response before it's returned. For example, you might need to log a particular header for each request. To do this, you can override the public `fetch` method like so:
+
+```ts
+  class MyDataSource extends RESTDataSource {
+    override async fetch<TResult>(
+      path: string,
+      incomingRequest: DataSourceRequest = {}
+    ) {
+      return super
+        .fetch<TResult>(path, incomingRequest)
+        .then(({ parsedBody, response }) => {
+          const header = response.headers.get('my-custom-header');
+          if (header) {
+            console.log(`Found header: ${header}`);
+          }
+          return { parsedBody, response };
+        });
+    }
+  }
+```
+
+This example leverages the default `fetch` implementation from the parent (`super`). We append our step to the promise chain, read the header, and return the original result that the `super.fetch` promise resolved to (`{ parsedBody, response }`).
 
 ### Integration with Apollo Server
 

--- a/README.md
+++ b/README.md
@@ -325,15 +325,12 @@ You might need to read or mutate the response before it's returned. For example,
       path: string,
       incomingRequest: DataSourceRequest = {}
     ) {
-      return super
-        .fetch<TResult>(path, incomingRequest)
-        .then(({ parsedBody, response }) => {
-          const header = response.headers.get('my-custom-header');
-          if (header) {
-            console.log(`Found header: ${header}`);
-          }
-          return { parsedBody, response };
-        });
+      const result = await super.fetch(path, incomingRequest);
+      const header = result.response.headers.get('my-custom-header');
+      if (header) {
+        console.log(`Found header: ${header}`);
+      }
+      return result;
     }
   }
 ```


### PR DESCRIPTION
It seems like the `didReceiveResponse` hook was fairly used and there's some uncertainty around how to upgrade to v5 now that it's missing. This adds a suggestion in the CHANGELOG and README to override the newly-public `fetch` method (while leveraging the default `fetch` implementation).

Fixes #143
Fixes #109