### PR TITLE
Update `didEncounterError` implemenation and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,9 @@ override cacheOptionsFor() {
 
 > Note: In previous versions of RESTDataSource (< v5), this hook was expected to throw the error it received (the default implementation did exactly that). This is no longer required; as mentioned below, the error will be thrown immediately after invoking `didEncounterError`.
 
-You can implement this observability hook in order to inspect (or modify) errors that are thrown while fetching, parsing the body (`parseBody()`), or by the `throwIfResponseIsError()` hook. The error that this hook receives will be thrown immediately after this hook is invoked.
+You can implement this hook in order to inspect (or modify) errors that are thrown while fetching, parsing the body (`parseBody()`), or by the `throwIfResponseIsError()` hook. The error that this hook receives will be thrown immediately after this hook is invoked.
+
+You can also throw a different error here altogether. Note that by default, errors are `GraphQLError`s (coming from `errorFromResponse`).
 
 ##### `parseBody`
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,10 @@ override cacheOptionsFor() {
 ```
 
 ##### `didEncounterError`
-By default, this method just throws the `error` it was given. If you override this method, you can choose to either perform some additional logic and still throw, or to swallow the error by not throwing the error result.
+
+> Note: In previous versions of RESTDataSource (< v5), this hook was expected to throw the error it received (the default implementation did exactly that). This is no longer required; as mentioned below, the error will be thrown immediately after invoking `didEncounterError`.
+
+You can implement this observability hook in order to inspect (or modify) errors that are thrown while fetching, parsing the body (`parseBody()`), or by the `throwIfResponseIsError()` hook. The error that this hook receives will be thrown immediately after this hook is invoked.
 
 ##### `parseBody`
 

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -257,9 +257,7 @@ export abstract class RESTDataSource {
     request: FetcherRequestInit,
   ): ValueOrPromise<CacheOptions | undefined>;
 
-  protected didEncounterError(error: Error, _request: RequestOptions) {
-    throw error;
-  }
+  protected didEncounterError?(error: Error, _request: RequestOptions): void;
 
   // Reads the body of the response and returns it in parsed form. If you want
   // to process data in some other way (eg, reading binary data), override this
@@ -531,7 +529,7 @@ export abstract class RESTDataSource {
             },
           };
         } catch (error) {
-          this.didEncounterError(error as Error, outgoingRequest);
+          this.didEncounterError?.(error as Error, outgoingRequest);
           throw error;
         }
       });

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -257,7 +257,12 @@ export abstract class RESTDataSource {
     request: FetcherRequestInit,
   ): ValueOrPromise<CacheOptions | undefined>;
 
-  protected didEncounterError?(error: Error, _request: RequestOptions): void;
+  protected didEncounterError(_error: Error, _request: RequestOptions) {
+    // left as a no-op instead of an unimplemented optional method to avoid
+    // breaking an existing use case where one calls
+    // `super.didEncounterErrors(...)` This could be unimplemented / undefined
+    // in a theoretical next major of this package.
+  }
 
   // Reads the body of the response and returns it in parsed form. If you want
   // to process data in some other way (eg, reading binary data), override this

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -534,7 +534,7 @@ export abstract class RESTDataSource {
             },
           };
         } catch (error) {
-          this.didEncounterError?.(error as Error, outgoingRequest);
+          this.didEncounterError(error as Error, outgoingRequest);
           throw error;
         }
       });

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -1905,16 +1905,16 @@ describe('RESTDataSource', () => {
           let encounteredError: Error | null = null;
           const dataSource = new (class extends RESTDataSource {
             override baseURL = 'https://api.example.com';
-  
+
             getFoo() {
               return this.get('foo');
             }
-  
+
             override didEncounterError(error: Error) {
               encounteredError = error;
             }
           })();
-  
+
           nock(apiUrl)
             .get('/foo')
             .reply(
@@ -1924,7 +1924,7 @@ describe('RESTDataSource', () => {
               },
               { 'content-type': 'application/json' },
             );
-  
+
           const result = dataSource.getFoo();
           await expect(result).rejects.toThrow(GraphQLError);
           await expect(result).rejects.toMatchObject({
@@ -1945,20 +1945,20 @@ describe('RESTDataSource', () => {
             message: '500: Internal Server Error',
           });
         });
-  
+
         it('can modify the error', async () => {
           const dataSource = new (class extends RESTDataSource {
             override baseURL = 'https://api.example.com';
-  
+
             getFoo() {
               return this.get('foo');
             }
-  
+
             override didEncounterError(error: Error) {
               error.message = 'Hello from didEncounterError';
             }
           })();
-  
+
           nock(apiUrl)
             .get('/foo')
             .reply(
@@ -1968,15 +1968,15 @@ describe('RESTDataSource', () => {
               },
               { 'content-type': 'application/json' },
             );
-  
+
           const result = dataSource.getFoo();
-  
+
           await expect(result).rejects.toThrow(GraphQLError);
           await expect(result).rejects.toMatchObject({
             message: 'Hello from didEncounterError',
           });
         });
-  
+
         it('can throw its own error', async () => {
           const dataSource = new (class extends RESTDataSource {
             override baseURL = 'https://api.example.com';
@@ -2008,7 +2008,7 @@ describe('RESTDataSource', () => {
             message: 'I replaced the error entirely',
           });
         });
-      })
+      });
     });
   });
 });

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -1899,6 +1899,116 @@ describe('RESTDataSource', () => {
           expect(calls).toBe(1);
         });
       });
+
+      describe('didEncounterError', () => {
+        it('is called with the error', async () => {
+          let encounteredError: Error | null = null;
+          const dataSource = new (class extends RESTDataSource {
+            override baseURL = 'https://api.example.com';
+  
+            getFoo() {
+              return this.get('foo');
+            }
+  
+            override didEncounterError(error: Error) {
+              encounteredError = error;
+            }
+          })();
+  
+          nock(apiUrl)
+            .get('/foo')
+            .reply(
+              500,
+              {
+                errors: [{ message: 'Houston, we have a problem.' }],
+              },
+              { 'content-type': 'application/json' },
+            );
+  
+          const result = dataSource.getFoo();
+          await expect(result).rejects.toThrow(GraphQLError);
+          await expect(result).rejects.toMatchObject({
+            extensions: {
+              response: {
+                status: 500,
+                body: {
+                  errors: [
+                    {
+                      message: 'Houston, we have a problem.',
+                    },
+                  ],
+                },
+              },
+            },
+          });
+          expect(encounteredError).toMatchObject({
+            message: '500: Internal Server Error',
+          });
+        });
+  
+        it('can modify the error', async () => {
+          const dataSource = new (class extends RESTDataSource {
+            override baseURL = 'https://api.example.com';
+  
+            getFoo() {
+              return this.get('foo');
+            }
+  
+            override didEncounterError(error: Error) {
+              error.message = 'Hello from didEncounterError';
+            }
+          })();
+  
+          nock(apiUrl)
+            .get('/foo')
+            .reply(
+              500,
+              {
+                errors: [{ message: 'Houston, we have a problem.' }],
+              },
+              { 'content-type': 'application/json' },
+            );
+  
+          const result = dataSource.getFoo();
+  
+          await expect(result).rejects.toThrow(GraphQLError);
+          await expect(result).rejects.toMatchObject({
+            message: 'Hello from didEncounterError',
+          });
+        });
+  
+        it('can throw its own error', async () => {
+          const dataSource = new (class extends RESTDataSource {
+            override baseURL = 'https://api.example.com';
+
+            getFoo() {
+              return this.get('foo');
+            }
+
+            override didEncounterError() {
+              throw new Error('I replaced the error entirely');
+            }
+          })();
+
+          nock(apiUrl)
+            .get('/foo')
+            .reply(
+              500,
+              {
+                errors: [{ message: 'Houston, we have a problem.' }],
+              },
+              { 'content-type': 'application/json' },
+            );
+
+          const result = dataSource.getFoo();
+
+          await expect(result).rejects.not.toThrow(GraphQLError);
+          await expect(result).rejects.toThrow(Error);
+          await expect(result).rejects.toMatchObject({
+            message: 'I replaced the error entirely',
+          });
+        });
+      })
     });
   });
 });


### PR DESCRIPTION
Sort of follow up to comments from #146.

The changes in https://github.com/apollographql/datasource-rest/pull/107 imposed a new requirement - either an error must be thrown or a response returned (from https://github.com/apollographql/datasource-rest/pull/107/files#diff-b20ea0c217d93b2062f468593a146a7574ae2d53733515f75b950bb584a50f86R353). Given that this error must be thrown, the default implementation of `didEncounterError` is redundant.

Furthermore, this updates the docs based on this less-strict-than-before requirement and clarifies the options available to implementors of this hook.

Within your implementation of `didEncounterError`, you can:
1) observe the error for logging and do nothing else
2) modify the incoming error (which will be thrown immediately after)
3) throw your own error (which bypasses throwing the original error immediately after)