### PR TITLE
Fix: Duplicate Content-Type header when Content-Type header is capitalized.

### DIFF
--- a/.changeset/rude-planets-kiss.md
+++ b/.changeset/rude-planets-kiss.md
@@ -1,0 +1,5 @@
+---
+'@apollo/datasource-rest': patch
+---
+
+Addresses duplicate content-type header bug due to upper-cased headers being forwarded. This change instead maps all headers to lowercased headers.

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -454,11 +454,11 @@ export abstract class RESTDataSource {
     path: string,
     incomingRequest: DataSourceRequest = {},
   ): Promise<DataSourceFetchResult<TResult>> {
-    let headers: Record<string, string> = {};
+    const downcasedHeaders: Record<string, string> = {};
     if (incomingRequest.headers) {
       // map incoming headers to lower-case headers
       Object.entries(incomingRequest.headers).forEach(([key, value]) => {
-        headers[key.toLowerCase()] = value;
+        downcasedHeaders[key.toLowerCase()] = value;
       });
     }
 
@@ -469,7 +469,7 @@ export abstract class RESTDataSource {
         incomingRequest.params instanceof URLSearchParams
           ? incomingRequest.params
           : this.urlSearchParamsFromRecord(incomingRequest.params),
-      headers: headers,
+      headers: downcasedHeaders,
     };
     // Default to GET in the case that `fetch` is called directly with no method
     // provided. Our other request methods all provide one.

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -483,6 +483,10 @@ export abstract class RESTDataSource {
       // If Content-Type header has not been previously set, set to application/json
       if (!augmentedRequest.headers) {
         augmentedRequest.headers = { 'content-type': 'application/json' };
+      // replace capitalized content-type header with lower case, ensures no dupliate content-types
+      } else if (augmentedRequest.headers['Content-Type']) {
+        augmentedRequest.headers['content-type'] = augmentedRequest.headers['Content-Type'];
+        delete augmentedRequest.headers['Content-Type'];
       } else if (!augmentedRequest.headers['content-type']) {
         augmentedRequest.headers['content-type'] = 'application/json';
       }

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -283,11 +283,142 @@ describe('RESTDataSource', () => {
 
       const data = await dataSource.postFoo();
       expect(spyOnHttpFetch.mock.calls[0][1]).toEqual({
-        headers: {"content-type": "application/json"},
-        body: "{\"foo\":\"bar\"}",
-        method: "POST",
-        params: new URLSearchParams()
-      })
+        headers: { 'content-type': 'application/json' },
+        body: '{"foo":"bar"}',
+        method: 'POST',
+        params: new URLSearchParams(),
+      });
+      expect(data).toEqual({ foo: 'bar' });
+    });
+
+    it('converts uppercase-containing headers to lowercase', async () => {
+      const requestOptions = {
+        headers: {
+          'Content-Type': 'application/json',
+          'Test-Header': 'foobar',
+          'ANOTHER-TEST-HEADER': 'test2',
+        },
+        body: JSON.parse(JSON.stringify({ foo: 'bar' })),
+      };
+      const dataSource = new (class extends RESTDataSource {
+        override baseURL = 'https://api.example.com';
+
+        postFoo() {
+          return this.post('foo', requestOptions);
+        }
+      })();
+
+      const spyOnHttpFetch = jest.spyOn(dataSource['httpCache'], 'fetch');
+
+      nock(apiUrl)
+        .post('/foo')
+        .reply(200, { foo: 'bar' }, { 'Content-Type': 'application/json' });
+
+      const data = await dataSource.postFoo();
+      expect(spyOnHttpFetch.mock.calls[0][1]).toEqual({
+        headers: {
+          'content-type': 'application/json',
+          'test-header': 'foobar',
+          'another-test-header': 'test2',
+        },
+        body: '{"foo":"bar"}',
+        method: 'POST',
+        params: new URLSearchParams(),
+      });
+      expect(data).toEqual({ foo: 'bar' });
+    });
+
+    it('adds a application/json content header', async () => {
+      const requestOptions = {
+        body: JSON.parse(JSON.stringify({ foo: 'bar' })),
+      };
+      const dataSource = new (class extends RESTDataSource {
+        override baseURL = 'https://api.example.com';
+
+        postFoo() {
+          return this.post('foo', requestOptions);
+        }
+      })();
+
+      const spyOnHttpFetch = jest.spyOn(dataSource['httpCache'], 'fetch');
+
+      nock(apiUrl)
+        .post('/foo')
+        .reply(200, { foo: 'bar' }, { 'Content-Type': 'application/json' });
+
+      const data = await dataSource.postFoo();
+      expect(spyOnHttpFetch.mock.calls[0][1]).toEqual({
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: '{"foo":"bar"}',
+        method: 'POST',
+        params: new URLSearchParams(),
+      });
+      expect(data).toEqual({ foo: 'bar' });
+    });
+
+    it('adds a application/json content header when no headers are passed in', async () => {
+      const requestOptions = {
+        body: JSON.parse(JSON.stringify({ foo: 'bar' })),
+      };
+      const dataSource = new (class extends RESTDataSource {
+        override baseURL = 'https://api.example.com';
+
+        postFoo() {
+          return this.post('foo', requestOptions);
+        }
+      })();
+
+      const spyOnHttpFetch = jest.spyOn(dataSource['httpCache'], 'fetch');
+
+      nock(apiUrl)
+        .post('/foo')
+        .reply(200, { foo: 'bar' }, { 'Content-Type': 'application/json' });
+
+      const data = await dataSource.postFoo();
+      expect(spyOnHttpFetch.mock.calls[0][1]).toEqual({
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: '{"foo":"bar"}',
+        method: 'POST',
+        params: new URLSearchParams(),
+      });
+      expect(data).toEqual({ foo: 'bar' });
+    });
+
+    it('adds a application/json content header when no content-type headers are passed in', async () => {
+      const requestOptions = {
+        headers: {
+          'test-header': 'foobar',
+        },
+        body: JSON.parse(JSON.stringify({ foo: 'bar' })),
+      };
+      const dataSource = new (class extends RESTDataSource {
+        override baseURL = 'https://api.example.com';
+
+        postFoo() {
+          return this.post('foo', requestOptions);
+        }
+      })();
+
+      const spyOnHttpFetch = jest.spyOn(dataSource['httpCache'], 'fetch');
+
+      nock(apiUrl)
+        .post('/foo')
+        .reply(200, { foo: 'bar' }, { 'Content-Type': 'application/json' });
+
+      const data = await dataSource.postFoo();
+      expect(spyOnHttpFetch.mock.calls[0][1]).toEqual({
+        headers: {
+          'content-type': 'application/json',
+          'test-header': 'foobar'
+        },
+        body: '{"foo":"bar"}',
+        method: 'POST',
+        params: new URLSearchParams(),
+      });
       expect(data).toEqual({ foo: 'bar' });
     });
 

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -360,7 +360,7 @@ describe('RESTDataSource', () => {
 
     it('adds an `application/json` content header when no headers are passed in', async () => {
       const requestOptions = {
-        body:  {foo: 'bar' },
+        body: { foo: 'bar' },
       };
       const dataSource = new (class extends RESTDataSource {
         override baseURL = 'https://api.example.com';

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -265,7 +265,7 @@ describe('RESTDataSource', () => {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.parse(JSON.stringify({ foo: 'bar' })),
+        body: { foo: 'bar' },
       };
       const dataSource = new (class extends RESTDataSource {
         override baseURL = 'https://api.example.com';
@@ -298,7 +298,7 @@ describe('RESTDataSource', () => {
           'Test-Header': 'foobar',
           'ANOTHER-TEST-HEADER': 'test2',
         },
-        body: JSON.parse(JSON.stringify({ foo: 'bar' })),
+        body: { foo: 'bar' },
       };
       const dataSource = new (class extends RESTDataSource {
         override baseURL = 'https://api.example.com';
@@ -328,9 +328,9 @@ describe('RESTDataSource', () => {
       expect(data).toEqual({ foo: 'bar' });
     });
 
-    it('adds a application/json content header', async () => {
+    it('adds an `application/json` content-type header when none is present', async () => {
       const requestOptions = {
-        body: JSON.parse(JSON.stringify({ foo: 'bar' })),
+        body: { foo: 'bar' },
       };
       const dataSource = new (class extends RESTDataSource {
         override baseURL = 'https://api.example.com';
@@ -358,9 +358,9 @@ describe('RESTDataSource', () => {
       expect(data).toEqual({ foo: 'bar' });
     });
 
-    it('adds a application/json content header when no headers are passed in', async () => {
+    it('adds an `application/json` content header when no headers are passed in', async () => {
       const requestOptions = {
-        body: JSON.parse(JSON.stringify({ foo: 'bar' })),
+        body:  {foo: 'bar' },
       };
       const dataSource = new (class extends RESTDataSource {
         override baseURL = 'https://api.example.com';
@@ -380,40 +380,6 @@ describe('RESTDataSource', () => {
       expect(spyOnHttpFetch.mock.calls[0][1]).toEqual({
         headers: {
           'content-type': 'application/json',
-        },
-        body: '{"foo":"bar"}',
-        method: 'POST',
-        params: new URLSearchParams(),
-      });
-      expect(data).toEqual({ foo: 'bar' });
-    });
-
-    it('adds a application/json content header when no content-type headers are passed in', async () => {
-      const requestOptions = {
-        headers: {
-          'test-header': 'foobar',
-        },
-        body: JSON.parse(JSON.stringify({ foo: 'bar' })),
-      };
-      const dataSource = new (class extends RESTDataSource {
-        override baseURL = 'https://api.example.com';
-
-        postFoo() {
-          return this.post('foo', requestOptions);
-        }
-      })();
-
-      const spyOnHttpFetch = jest.spyOn(dataSource['httpCache'], 'fetch');
-
-      nock(apiUrl)
-        .post('/foo')
-        .reply(200, { foo: 'bar' }, { 'Content-Type': 'application/json' });
-
-      const data = await dataSource.postFoo();
-      expect(spyOnHttpFetch.mock.calls[0][1]).toEqual({
-        headers: {
-          'content-type': 'application/json',
-          'test-header': 'foobar'
         },
         body: '{"foo":"bar"}',
         method: 'POST',


### PR DESCRIPTION
When a `Content-Type` header exists in a `incomingRequest` object that is passed into the `fetch` function, we will receive a duplicate lowercase `content-type` header.

[Here](https://github.com/apollographql/datasource-rest/blob/9a8b6278d80bc677fa7608ac0c3f065d991a79af/src/RESTDataSource.ts#L486) is where the error occurs in the source code
```
    if (this.shouldJSONSerializeBody(augmentedRequest.body)) {
      augmentedRequest.body = JSON.stringify(augmentedRequest.body);
      // If Content-Type header has not been previously set, set to application/json
      if (!augmentedRequest.headers) {
        augmentedRequest.headers = { 'content-type': 'application/json' };
      } else if (!augmentedRequest.headers['content-type']) {
        augmentedRequest.headers['content-type'] = 'application/json';
      }
```

What my proposed change does is it checks for the capitalized `Content-Type` header, if it exists we create a lowercase `content-type` header and delete the capitalized one.

Alternatively, we could just change the above if statement to:
```
else if (!augmentedRequest.headers['content-type'] && !augmentedRequest.headers['Content-Type']) {
```
