### PR TITLE
Update `http-cache-semantics` package

### DIFF
--- a/.changeset/five-snails-stare.md
+++ b/.changeset/five-snails-stare.md
@@ -3,4 +3,17 @@
 ---
 
 Update `http-cache-semantics` package to latest patch, resolving a security issue.
+
+Unlike many security updates Apollo repos receive, this is an _actual_ (non-dev)
+dependency of this package which means it is actually a user-facing security issue.
+
+Since `http-cache-semantics` is a careted (^) dependency in this package, the
+security issue can (and might already) be resolved via a `package-lock.json`
+update within your project (possibly triggered by `npm audit` or another
+dependency update which has already updated its version of the package in
+question). If `npm ls http-cache-semantics` reveals a tree of dependencies which
+only include the `4.1.1` version (and no references to any previous versions)
+then you are currently unaffected and this patch should have (for all intents
+and purpose) no effect.
+
 More details available here: https://github.com/advisories/GHSA-rc47-6667-2j5j

--- a/.changeset/five-snails-stare.md
+++ b/.changeset/five-snails-stare.md
@@ -7,6 +7,11 @@ Update `http-cache-semantics` package to latest patch, resolving a security issu
 Unlike many security updates Apollo repos receive, this is an _actual_ (non-dev)
 dependency of this package which means it is actually a user-facing security issue.
 
+This security issue would only affect you if either:
+* you pass untrusted (i.e. from your users) `cache-control` request headers
+* you sending requests to untrusted REST server that might return malicious
+  `cache-control` headers
+
 Since `http-cache-semantics` is a careted (^) dependency in this package, the
 security issue can (and might already) be resolved via a `package-lock.json`
 update within your project (possibly triggered by `npm audit` or another

--- a/.changeset/five-snails-stare.md
+++ b/.changeset/five-snails-stare.md
@@ -1,0 +1,6 @@
+---
+'@apollo/datasource-rest': patch
+---
+
+Update `http-cache-semantics` package to latest patch, resolving a security issue.
+More details available here: https://github.com/advisories/GHSA-rc47-6667-2j5j

--- a/.changeset/five-snails-stare.md
+++ b/.changeset/five-snails-stare.md
@@ -2,10 +2,15 @@
 '@apollo/datasource-rest': patch
 ---
 
-Update `http-cache-semantics` package to latest patch, resolving a security issue.
+Update `http-cache-semantics` package to latest patch, resolving a security
+issue.
 
 Unlike many security updates Apollo repos receive, this is an _actual_ (non-dev)
-dependency of this package which means it is actually a user-facing security issue.
+dependency of this package which means it is actually a user-facing security
+issue.
+
+The potential impact of this issue is limited to a DOS attack (via an
+inefficient regex).
 
 This security issue would only affect you if either:
 * you pass untrusted (i.e. from your users) `cache-control` request headers

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.keyvaluecache": "^2.0.0",
         "@types/http-cache-semantics": "^4.0.1",
-        "http-cache-semantics": "^4.1.0",
+        "http-cache-semantics": "^4.1.1",
         "lodash.isplainobject": "^4.0.6",
         "node-fetch": "^2.6.7"
       },
@@ -5207,9 +5207,9 @@
       "dev": true
     },
     "node_modules/http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -14132,9 +14132,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
     "http-errors": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@apollo/utils.fetcher": "^2.0.0",
     "@apollo/utils.keyvaluecache": "^2.0.0",
     "@types/http-cache-semantics": "^4.0.1",
-    "http-cache-semantics": "^4.1.0",
+    "http-cache-semantics": "^4.1.1",
     "lodash.isplainobject": "^4.0.6",
     "node-fetch": "^2.6.7"
   },


### PR DESCRIPTION
Update `http-cache-semantics` package to latest patch, resolving a security issue. Unlike many security updates Apollo repos receive, this is an _actual_ (non-dev) dependency of this package which means it is actually a user-facing security issue.

The potential impact of this issue is limited to a DOS attack (via an
inefficient regex).

This security issue would only affect you if either:
* you pass untrusted (i.e. from your users) `cache-control` request headers
* you sending requests to untrusted REST server that might return malicious
  `cache-control` headers

Since `http-cache-semantics` is a careted (^) dependency in this package, the security issue can (and might already) be resolved via a `package-lock.json` update within your project (possibly triggered by `npm audit` or another dependency update which has already updated its version of the package in question). If `npm ls http-cache-semantics` reveals a tree of dependencies which only include the `4.1.1` version (and no references to any previous versions) then you are currently unaffected and this patch should have (for all intents and purpose) no effect.

More details available here: https://github.com/advisories/GHSA-rc47-6667-2j5j