### PR TITLE
Add `@apollo/utils.withrequired` type to dependencies

### DIFF
--- a/.changeset/nasty-walls-kneel.md
+++ b/.changeset/nasty-walls-kneel.md
@@ -1,0 +1,6 @@
+---
+'@apollo/datasource-rest': patch
+---
+
+Add missing `@apollo/utils.withrequired` type dependency which is part of the
+public typings (via the `AugmentedRequest` type).

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.keyvaluecache": "^2.0.0",
+        "@apollo/utils.withrequired": "^2.0.0",
         "@types/http-cache-semantics": "^4.0.1",
         "http-cache-semantics": "^4.1.0",
         "lodash.isplainobject": "^4.0.6",
@@ -18,7 +19,6 @@
       },
       "devDependencies": {
         "@apollo/server": "4.3.2",
-        "@apollo/utils.withrequired": "2.0.0",
         "@changesets/changelog-github": "0.4.8",
         "@changesets/cli": "2.26.0",
         "@types/jest": "29.4.0",
@@ -322,7 +322,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-2.0.0.tgz",
       "integrity": "sha512-+djpTu6AEE/A1etryZs9tmXRyDY6XXGe3G29MS/LB09uHq3pcl3n4Q5lvDTL5JWKuJixrulg5djePLDAooG8dQ==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       }
@@ -10144,8 +10143,7 @@
     "@apollo/utils.withrequired": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@apollo/utils.withrequired/-/utils.withrequired-2.0.0.tgz",
-      "integrity": "sha512-+djpTu6AEE/A1etryZs9tmXRyDY6XXGe3G29MS/LB09uHq3pcl3n4Q5lvDTL5JWKuJixrulg5djePLDAooG8dQ==",
-      "dev": true
+      "integrity": "sha512-+djpTu6AEE/A1etryZs9tmXRyDY6XXGe3G29MS/LB09uHq3pcl3n4Q5lvDTL5JWKuJixrulg5djePLDAooG8dQ=="
     },
     "@babel/code-frame": {
       "version": "7.16.7",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "@apollo/server": "4.3.2",
-    "@apollo/utils.withrequired": "2.0.0",
     "@changesets/changelog-github": "0.4.8",
     "@changesets/cli": "2.26.0",
     "@types/jest": "29.4.0",
@@ -51,6 +50,7 @@
   "dependencies": {
     "@apollo/utils.fetcher": "^2.0.0",
     "@apollo/utils.keyvaluecache": "^2.0.0",
+    "@apollo/utils.withrequired": "^2.0.0",
     "@types/http-cache-semantics": "^4.0.1",
     "http-cache-semantics": "^4.1.0",
     "lodash.isplainobject": "^4.0.6",


### PR DESCRIPTION
Fixes #152

`WithRequired` is transitively part of the public typings for this package so it should be a dependency (not just a development dependency). Currently users who import the `AugmentedRequest` type exported by this package must bring their own `WithRequired` (either directly or transitively).