### PR TITLE
feat: Allow for custom logger to be configured and default to console

### DIFF
--- a/.changeset/great-windows-warn.md
+++ b/.changeset/great-windows-warn.md
@@ -1,0 +1,18 @@
+---
+'@apollo/datasource-rest': minor
+---
+
+Customize the logger used by `RESTDataSource`.
+By default the `RESTDataSource` will use `console`.
+Common use cases would be to override the default logger with `pino` or `winston`.
+
+E.g.
+```typescript
+const pino = require('pino');
+const loggerPino = pino({});
+const dataSource = new (class extends RESTDataSource {})({
+  logger: loggerPino,
+});
+```
+
+All logging calls made by the `RESTDataSource` will now use the `pino` logger instead of the `console` logger.

--- a/.changeset/great-windows-warn.md
+++ b/.changeset/great-windows-warn.md
@@ -15,4 +15,4 @@ const dataSource = new (class extends RESTDataSource {})({
 });
 ```
 
-All logging calls made by the `RESTDataSource` will now use the `pino` logger instead of the `console` logger.
+In the example above, all logging calls made by the `RESTDataSource` will now use the `pino` logger instead of the `console` logger.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,25 @@ class MoviesAPI extends RESTDataSource {
 
 This README lists all the protected methods. In practice, if you're looking to customize behavior by overriding methods, reading the [source code](https://github.com/apollographql/datasource-rest/tree/main/src/RESTDataSource.ts) is the best option.
 
+#### Constructor
+
+The `RESTDataSource` takes in a `DataSourceConfig` which allows for overriding some default behavior.
+
+Configuration Overrides
+  - `cache` - Custom [`KeyValueCache`](https://www.npmjs.com/package/@apollo/utils.keyvaluecache) implementation
+  - `fetch` - Custom [`Fetcher`](https://www.npmjs.com/package/@apollo/utils.fetcher) implementation
+  - `logger` - Custom [`Logger`](https://www.npmjs.com/package/@apollo/utils.logger) implementation that will replace all logging activity within `RESTDataSource`
+
+To override the RESTDataSource, see the following example code:
+
+```typescript
+const dataSource = new (class extends RESTDataSource {})({
+  cache: customCache,
+  fetch: customFetcher,
+  logger: customLogger,
+});
+```
+
 #### Properties
 
 ##### `baseURL`

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@apollo/server": "4.7.0",
+        "@apollo/utils.logger": "^3.0.0",
         "@changesets/changelog-github": "0.4.8",
         "@changesets/cli": "2.26.1",
         "@types/jest": "29.5.1",
@@ -146,6 +147,24 @@
         "graphql": "14.x || 15.x || 16.x"
       }
     },
+    "node_modules/@apollo/server-gateway-interface/node_modules/@apollo/utils.logger": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/@apollo/utils.logger": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@apollo/server/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -227,6 +246,14 @@
         "node": ">=14"
       }
     },
+    "node_modules/@apollo/utils.keyvaluecache/node_modules/@apollo/utils.logger": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@apollo/utils.keyvaluecache/node_modules/lru-cache": {
       "version": "7.14.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
@@ -236,11 +263,12 @@
       }
     },
     "node_modules/@apollo/utils.logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-3.0.0.tgz",
+      "integrity": "sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg==",
+      "dev": true,
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@apollo/utils.printwithreducedwhitespace": {
@@ -10972,6 +11000,12 @@
         "whatwg-mimetype": "^3.0.0"
       },
       "dependencies": {
+        "@apollo/utils.logger": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+          "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
+          "dev": true
+        },
         "lru-cache": {
           "version": "7.18.3",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -10996,6 +11030,14 @@
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.keyvaluecache": "^2.1.0",
         "@apollo/utils.logger": "^2.0.0"
+      },
+      "dependencies": {
+        "@apollo/utils.logger": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+          "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
+          "dev": true
+        }
       }
     },
     "@apollo/usage-reporting-protobuf": {
@@ -11044,6 +11086,11 @@
         "lru-cache": "^7.14.1"
       },
       "dependencies": {
+        "@apollo/utils.logger": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+          "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg=="
+        },
         "lru-cache": {
           "version": "7.14.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
@@ -11052,9 +11099,10 @@
       }
     },
     "@apollo/utils.logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-3.0.0.tgz",
+      "integrity": "sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg==",
+      "dev": true
     },
     "@apollo/utils.printwithreducedwhitespace": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
       },
       "devDependencies": {
         "@apollo/server": "4.6.0",
-        "@apollo/utils.logger": "^3.0.0",
         "@changesets/changelog-github": "0.4.8",
         "@changesets/cli": "2.26.1",
         "@types/jest": "29.5.0",
@@ -260,15 +259,6 @@
       "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@apollo/utils.logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-3.0.0.tgz",
-      "integrity": "sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg==",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@apollo/utils.printwithreducedwhitespace": {
@@ -11097,12 +11087,6 @@
           "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
         }
       }
-    },
-    "@apollo/utils.logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-3.0.0.tgz",
-      "integrity": "sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg==",
-      "dev": true
     },
     "@apollo/utils.printwithreducedwhitespace": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.keyvaluecache": "^2.0.0",
+        "@apollo/utils.logger": "^2.0.1",
         "@apollo/utils.withrequired": "^2.0.0",
         "@types/http-cache-semantics": "^4.0.1",
         "http-cache-semantics": "^4.1.1",
@@ -19,7 +20,6 @@
       },
       "devDependencies": {
         "@apollo/server": "4.7.0",
-        "@apollo/utils.logger": "^3.0.0",
         "@changesets/changelog-github": "0.4.8",
         "@changesets/cli": "2.26.1",
         "@types/jest": "29.5.1",
@@ -147,24 +147,6 @@
         "graphql": "14.x || 15.x || 16.x"
       }
     },
-    "node_modules/@apollo/server-gateway-interface/node_modules/@apollo/utils.logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
-      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@apollo/utils.logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
-      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@apollo/server/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -246,14 +228,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@apollo/utils.keyvaluecache/node_modules/@apollo/utils.logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
-      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@apollo/utils.keyvaluecache/node_modules/lru-cache": {
       "version": "7.14.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
@@ -263,12 +237,11 @@
       }
     },
     "node_modules/@apollo/utils.logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-3.0.0.tgz",
-      "integrity": "sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg==",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/@apollo/utils.printwithreducedwhitespace": {
@@ -11000,12 +10973,6 @@
         "whatwg-mimetype": "^3.0.0"
       },
       "dependencies": {
-        "@apollo/utils.logger": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
-          "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
-          "dev": true
-        },
         "lru-cache": {
           "version": "7.18.3",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -11030,14 +10997,6 @@
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.keyvaluecache": "^2.1.0",
         "@apollo/utils.logger": "^2.0.0"
-      },
-      "dependencies": {
-        "@apollo/utils.logger": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
-          "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
-          "dev": true
-        }
       }
     },
     "@apollo/usage-reporting-protobuf": {
@@ -11086,11 +11045,6 @@
         "lru-cache": "^7.14.1"
       },
       "dependencies": {
-        "@apollo/utils.logger": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
-          "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg=="
-        },
         "lru-cache": {
           "version": "7.14.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
@@ -11099,10 +11053,9 @@
       }
     },
     "@apollo/utils.logger": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-3.0.0.tgz",
-      "integrity": "sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg==",
-      "dev": true
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg=="
     },
     "@apollo/utils.printwithreducedwhitespace": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@apollo/server": "4.6.0",
+        "@apollo/utils.logger": "^3.0.0",
         "@changesets/changelog-github": "0.4.8",
         "@changesets/cli": "2.26.1",
         "@types/jest": "29.5.0",
@@ -146,6 +147,24 @@
         "graphql": "14.x || 15.x || 16.x"
       }
     },
+    "node_modules/@apollo/server-gateway-interface/node_modules/@apollo/utils.logger": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@apollo/server/node_modules/@apollo/utils.logger": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@apollo/server/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -227,6 +246,14 @@
         "node": ">=14"
       }
     },
+    "node_modules/@apollo/utils.keyvaluecache/node_modules/@apollo/utils.logger": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@apollo/utils.keyvaluecache/node_modules/lru-cache": {
       "version": "7.14.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
@@ -236,11 +263,12 @@
       }
     },
     "node_modules/@apollo/utils.logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-3.0.0.tgz",
+      "integrity": "sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg==",
+      "dev": true,
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@apollo/utils.printwithreducedwhitespace": {
@@ -10972,6 +11000,12 @@
         "whatwg-mimetype": "^3.0.0"
       },
       "dependencies": {
+        "@apollo/utils.logger": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+          "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
+          "dev": true
+        },
         "lru-cache": {
           "version": "7.18.3",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -10996,6 +11030,14 @@
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.keyvaluecache": "^2.1.0",
         "@apollo/utils.logger": "^2.0.0"
+      },
+      "dependencies": {
+        "@apollo/utils.logger": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+          "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
+          "dev": true
+        }
       }
     },
     "@apollo/usage-reporting-protobuf": {
@@ -11044,6 +11086,11 @@
         "lru-cache": "^7.14.1"
       },
       "dependencies": {
+        "@apollo/utils.logger": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
+          "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg=="
+        },
         "lru-cache": {
           "version": "7.14.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
@@ -11052,9 +11099,10 @@
       }
     },
     "@apollo/utils.logger": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
-      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-3.0.0.tgz",
+      "integrity": "sha512-M8V8JOTH0F2qEi+ktPfw4RL7MvUycDfKp7aEap2eWXfL5SqWHN6jTLbj5f5fj1cceHpyaUSOZlvlaaryaxZAmg==",
+      "dev": true
     },
     "@apollo/utils.printwithreducedwhitespace": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -146,24 +146,6 @@
         "graphql": "14.x || 15.x || 16.x"
       }
     },
-    "node_modules/@apollo/server-gateway-interface/node_modules/@apollo/utils.logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
-      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@apollo/server/node_modules/@apollo/utils.logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
-      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@apollo/server/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -245,20 +227,20 @@
         "node": ">=14"
       }
     },
-    "node_modules/@apollo/utils.keyvaluecache/node_modules/@apollo/utils.logger": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
-      "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@apollo/utils.keyvaluecache/node_modules/lru-cache": {
       "version": "7.14.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
       "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA==",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@apollo/utils.logger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
+      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@apollo/utils.printwithreducedwhitespace": {
@@ -10990,12 +10972,6 @@
         "whatwg-mimetype": "^3.0.0"
       },
       "dependencies": {
-        "@apollo/utils.logger": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
-          "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
-          "dev": true
-        },
         "lru-cache": {
           "version": "7.18.3",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -11020,14 +10996,6 @@
         "@apollo/utils.fetcher": "^2.0.0",
         "@apollo/utils.keyvaluecache": "^2.1.0",
         "@apollo/utils.logger": "^2.0.0"
-      },
-      "dependencies": {
-        "@apollo/utils.logger": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
-          "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==",
-          "dev": true
-        }
       }
     },
     "@apollo/usage-reporting-protobuf": {
@@ -11076,17 +11044,17 @@
         "lru-cache": "^7.14.1"
       },
       "dependencies": {
-        "@apollo/utils.logger": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.1.tgz",
-          "integrity": "sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg=="
-        },
         "lru-cache": {
           "version": "7.14.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
           "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
         }
       }
+    },
+    "@apollo/utils.logger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@apollo/utils.logger/-/utils.logger-2.0.0.tgz",
+      "integrity": "sha512-o8qYwgV2sYg+PcGKIfwAZaZsQOTEfV8q3mH7Pw8GB/I/Uh2L9iaHdpiKuR++j7oe1K87lFm0z/JAezMOR9CGhg=="
     },
     "@apollo/utils.printwithreducedwhitespace": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@apollo/server": "4.7.0",
+    "@apollo/utils.logger": "^3.0.0",
     "@changesets/changelog-github": "0.4.8",
     "@changesets/cli": "2.26.1",
     "@types/jest": "29.5.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "devDependencies": {
     "@apollo/server": "4.6.0",
-    "@apollo/utils.logger": "^3.0.0",
     "@changesets/changelog-github": "0.4.8",
     "@changesets/cli": "2.26.1",
     "@types/jest": "29.5.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   },
   "devDependencies": {
     "@apollo/server": "4.7.0",
-    "@apollo/utils.logger": "^3.0.0",
     "@changesets/changelog-github": "0.4.8",
     "@changesets/cli": "2.26.1",
     "@types/jest": "29.5.1",
@@ -55,6 +54,7 @@
   "dependencies": {
     "@apollo/utils.fetcher": "^2.0.0",
     "@apollo/utils.keyvaluecache": "^2.0.0",
+    "@apollo/utils.logger": "^2.0.1",
     "@apollo/utils.withrequired": "^2.0.0",
     "@types/http-cache-semantics": "^4.0.1",
     "http-cache-semantics": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@apollo/server": "4.6.0",
+    "@apollo/utils.logger": "^3.0.0",
     "@changesets/changelog-github": "0.4.8",
     "@changesets/cli": "2.26.1",
     "@types/jest": "29.5.0",

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -8,6 +8,7 @@ import type { WithRequired } from '@apollo/utils.withrequired';
 import { GraphQLError } from 'graphql';
 import isPlainObject from 'lodash.isplainobject';
 import { HTTPCache } from './HTTPCache';
+import type { Logger } from '@apollo/utils.logger';
 import type { Options as HttpCacheSemanticsOptions } from 'http-cache-semantics';
 
 export type ValueOrPromise<T> = T | Promise<T>;
@@ -171,11 +172,6 @@ export type RequestDeduplicationPolicy =
   // doing (say) `DELETE /path` invalidates any result for `GET /path` within
   // the deduplication store.)
   | { policy: 'do-not-deduplicate'; invalidateDeduplicationKeys?: string[] };
-
-export interface Logger {
-  info(msg: string): void;
-  error(error: any, ...data: any[]): void;
-}
 
 export abstract class RESTDataSource {
   protected httpCache: HTTPCache;

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -185,7 +185,7 @@ export abstract class RESTDataSource {
 
   constructor(config?: DataSourceConfig) {
     this.httpCache = new HTTPCache(config?.cache, config?.fetch);
-    this.logger = config?.logger ? config.logger : console;
+    this.logger = config?.logger ?? console;
   }
 
   // By default, we use `cacheKey` from the request if provided, or the full

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -613,7 +613,7 @@ export abstract class RESTDataSource {
   // Override this method to handle these errors in a different way.
   protected catchCacheWritePromiseErrors(cacheWritePromise: Promise<void>) {
     cacheWritePromise.catch((e) => {
-      console.error(`Error writing from RESTDataSource to cache: ${e}`);
+      this.logger.error(`Error writing from RESTDataSource to cache: ${e}`);
     });
   }
 

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -14,6 +14,7 @@ import nock from 'nock';
 import { nockAfterEach, nockBeforeEach } from './nockAssertions';
 import type { WithRequired } from '@apollo/utils.withrequired';
 import { Headers as NodeFetchHeaders } from 'node-fetch';
+import type { Logger } from '@apollo/utils.logger';
 
 const apiUrl = 'https://api.example.com';
 
@@ -21,7 +22,29 @@ describe('RESTDataSource', () => {
   beforeEach(nockBeforeEach);
   afterEach(nockAfterEach);
 
+  it('not overriding logger will use "console" as logger', async () => {
+    const dataSource = new (class extends RESTDataSource {})();
+
+    expect(dataSource.logger).toEqual(console)
+  });
+
+  it('providing override to logger will use "console" as logger', async () => {
+    const testLogger: Logger = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+    }
+    const dataSource = new (class extends RESTDataSource {})({
+      logger: testLogger
+    });
+
+    expect(dataSource.logger).not.toEqual(console)
+    expect(dataSource.logger).toEqual(testLogger)
+  });
+
   describe('constructing requests', () => {
+
     it('interprets paths relative to the base URL', async () => {
       const dataSource = new (class extends RESTDataSource {
         override baseURL = apiUrl;

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -25,7 +25,7 @@ describe('RESTDataSource', () => {
   it('not overriding logger will use "console" as logger', async () => {
     const dataSource = new (class extends RESTDataSource {})();
 
-    expect(dataSource.logger).toEqual(console)
+    expect(dataSource.logger).toEqual(console);
   });
 
   it('providing override to logger will use "console" as logger', async () => {
@@ -34,17 +34,16 @@ describe('RESTDataSource', () => {
       info: jest.fn(),
       error: jest.fn(),
       warn: jest.fn(),
-    }
+    };
     const dataSource = new (class extends RESTDataSource {})({
-      logger: testLogger
+      logger: testLogger,
     });
 
-    expect(dataSource.logger).not.toEqual(console)
-    expect(dataSource.logger).toEqual(testLogger)
+    expect(dataSource.logger).not.toEqual(console);
+    expect(dataSource.logger).toEqual(testLogger);
   });
 
   describe('constructing requests', () => {
-
     it('interprets paths relative to the base URL', async () => {
       const dataSource = new (class extends RESTDataSource {
         override baseURL = apiUrl;


### PR DESCRIPTION
`datasource-rest` was using the `console` log for all info messages. This PR Allows overriding the default logger with a custom logger implementation, by default it uses the `console` log.