### PR TITLE
fix: Don't crash when receiving non-string, non-array headers

### DIFF
--- a/.changeset/polite-trainers-camp.md
+++ b/.changeset/polite-trainers-camp.md
@@ -1,0 +1,5 @@
+---
+'@apollo/datasource-rest': patch
+---
+
+Don't crash when receiving non-string, non-array headers

--- a/src/HTTPCache.ts
+++ b/src/HTTPCache.ts
@@ -331,12 +331,12 @@ function cachePolicyHeadersToNodeFetchHeadersInit(
 ): NodeFetchHeadersInit {
   const headerList = [];
   for (const [name, value] of Object.entries(headers)) {
-    if (typeof value === 'string') {
-      headerList.push([name, value]);
-    } else if (value) {
+    if (Array.isArray(value)) {
       for (const subValue of value) {
         headerList.push([name, subValue]);
       }
+    } else if (value) {
+      headerList.push([name, value]);
     }
   }
   return headerList;
@@ -354,10 +354,10 @@ function cachePolicyHeadersToFetcherHeadersInit(
 ): Record<string, string> {
   const headerRecord = Object.create(null);
   for (const [name, value] of Object.entries(headers)) {
-    if (typeof value === 'string') {
-      headerRecord[name] = value;
-    } else if (value) {
+    if (Array.isArray(value)) {
       headerRecord[name] = value.join(', ');
+    } else if (value) {
+      headerRecord[name] = value;
     }
   }
   return headerRecord;


### PR DESCRIPTION
I recently encountered an obscure bug, value.join is not a function, that was hard to track down. While one probably shouldn't be sending weird data to headers, in this case it was a boolean which would stringify okay. This change should keep everything functionally the same but be slightly more defensive and avoid such a crash.