### PR TITLE
Fix Cloudflare Workers usage re:`Headers` weirdness

### DIFF
--- a/.changeset/smart-tools-occur.md
+++ b/.changeset/smart-tools-occur.md
@@ -1,0 +1,7 @@
+---
+'@apollo/datasource-rest': patch
+---
+
+Fix bug in Cloudflare Worker usage where we try to call the `.raw()` method on its response headers object when it doesn't exist.
+
+For some reason, the Cloudflare Worker's global `fetch` `HeadersList` object is passing the instanceof check against `node-fetch`'s `Headers` class, but it doesn't have the `.raw()` method we expect on it. To be sure, we can just make sure it's there before we call it.

--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -14,6 +14,7 @@ direnv
 Fakeable
 falsey
 httpcache
+instanceof
 isplainobject
 keyvaluecache
 overridable

--- a/src/HTTPCache.ts
+++ b/src/HTTPCache.ts
@@ -295,12 +295,12 @@ function policyResponseFrom(response: FetcherResponse) {
   return {
     status: response.status,
     headers:
-      response.headers instanceof NodeFetchHeaders
-        // https://github.com/apollo-server-integrations/apollo-server-integration-cloudflare-workers/issues/37
-        // For some reason, Cloudflare Workers' `response.headers` is passing
-        // the instanceof check here but doesn't have the `raw()` method that
-        // node-fetch's headers have.
-        && 'raw' in response.headers
+      response.headers instanceof NodeFetchHeaders &&
+      // https://github.com/apollo-server-integrations/apollo-server-integration-cloudflare-workers/issues/37
+      // For some reason, Cloudflare Workers' `response.headers` is passing
+      // the instanceof check here but doesn't have the `raw()` method that
+      // node-fetch's headers have.
+      'raw' in response.headers
         ? nodeFetchHeadersToCachePolicyHeaders(response.headers)
         : Object.fromEntries(response.headers),
   };

--- a/src/HTTPCache.ts
+++ b/src/HTTPCache.ts
@@ -296,6 +296,11 @@ function policyResponseFrom(response: FetcherResponse) {
     status: response.status,
     headers:
       response.headers instanceof NodeFetchHeaders
+        // https://github.com/apollo-server-integrations/apollo-server-integration-cloudflare-workers/issues/37
+        // For some reason, Cloudflare Workers' `response.headers` is passing
+        // the instanceof check here but doesn't have the `raw()` method that
+        // node-fetch's headers have.
+        && 'raw' in response.headers
         ? nodeFetchHeadersToCachePolicyHeaders(response.headers)
         : Object.fromEntries(response.headers),
   };


### PR DESCRIPTION
Ref: https://github.com/apollo-server-integrations/apollo-server-integration-cloudflare-workers/issues/37

After some quick debugging with the example provided in the linked issue, I was able to see that CF's `response.headers` object was passing the `instanceof` check for `node-fetch`'s `Headers` class, but it didn't have the `.raw()` method we expected on it. This change adds an extra check for existence of the `raw` method to be sure its there before we try to call it.

I can't explain the `instanceof` weirdness and not going to dig into it too deeply.