### PR TITLE
fix: upstream content length can be not specified

### DIFF
--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -284,6 +284,7 @@ export abstract class RESTDataSource {
       // isn't enough to `JSON.parse`, and trying will result in an error.
       response.status !== 204 &&
       contentLength !== '0' &&
+      contentLength !== null &&
       contentType &&
       (contentType.startsWith('application/json') ||
         contentType.endsWith('+json'))


### PR DESCRIPTION
Upstream content length can be not specified. This results in contentLength variable being null. Add additional check to handle this case.