### PR TITLE
Refactor errorFromResponse

### DIFF
--- a/.changeset/tricky-keys-press.md
+++ b/.changeset/tricky-keys-press.md
@@ -1,0 +1,5 @@
+---
+'@apollo/datasource-rest': patch
+---
+
+Make `request` and `url` optional parameters in the `errorFromResponse` method and clean up the implementation.

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -361,13 +361,15 @@ export abstract class RESTDataSource {
     response: FetcherResponse;
     parsedBody: unknown;
   }) {
+    const codeByStatus = new Map<number, string>([
+      [401, 'UNAUTHENTICATED'],
+      [403, 'FORBIDDEN'],
+    ]);
+    const code = codeByStatus.get(response.status);
+
     return new GraphQLError(`${response.status}: ${response.statusText}`, {
       extensions: {
-        ...(response.status === 401
-          ? { code: 'UNAUTHENTICATED' }
-          : response.status === 403
-          ? { code: 'FORBIDDEN' }
-          : {}),
+        ...(code && { code }),
         response: {
           url: response.url,
           status: response.status,

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -356,8 +356,8 @@ export abstract class RESTDataSource {
     response,
     parsedBody,
   }: {
-    url: URL;
-    request: RequestOptions;
+    url?: URL;
+    request?: RequestOptions;
     response: FetcherResponse;
     parsedBody: unknown;
   }) {

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -1638,6 +1638,7 @@ describe('RESTDataSource', () => {
             },
           },
         });
+        await expect(result).rejects.not.toHaveProperty('extensions.code');
       });
 
       it('puts JSON error responses on the error as an object', async () => {


### PR DESCRIPTION
## Description
- Turn `url` and `request` into optional parameters
- Refactor the way to add `code` in the `extensions` object

Fixes #247