### PR TITLE
use lodash cloneDeep to clone parsed body

### DIFF
--- a/.changeset/fluffy-ants-appear.md
+++ b/.changeset/fluffy-ants-appear.md
@@ -1,5 +1,5 @@
 ---
-'@apollo/datasource-rest': minor
+'@apollo/datasource-rest': patch
 ---
 
-use lodash to clone parsed body
+Use lodash's `cloneDeep` to clone parsed body instead of `JSON.parse(JSON.stringify(...))`

--- a/.changeset/fluffy-ants-appear.md
+++ b/.changeset/fluffy-ants-appear.md
@@ -1,0 +1,5 @@
+---
+'@apollo/datasource-rest': minor
+---
+
+use lodash to clone parsed body

--- a/cspell-dict.txt
+++ b/cspell-dict.txt
@@ -7,6 +7,7 @@ careted
 changesets
 cimg
 circleci
+clonedeep
 codesandbox
 concat
 datasource

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@changesets/changelog-github": "0.4.8",
         "@changesets/cli": "2.26.2",
         "@types/jest": "29.5.5",
-        "@types/lodash.clonedeep": "^4.5.7",
+        "@types/lodash.clonedeep": "4.5.7",
         "@types/lodash.isplainobject": "4.0.7",
         "@types/node": "16.18.58",
         "@typescript-eslint/eslint-plugin": "6.7.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@apollo/utils.withrequired": "^3.0.0",
         "@types/http-cache-semantics": "^4.0.1",
         "http-cache-semantics": "^4.1.1",
+        "lodash.clonedeep": "^4.5.0",
         "lodash.isplainobject": "^4.0.6",
         "node-fetch": "^2.6.7"
       },
@@ -23,6 +24,7 @@
         "@changesets/changelog-github": "0.4.8",
         "@changesets/cli": "2.26.2",
         "@types/jest": "29.5.5",
+        "@types/lodash.clonedeep": "^4.5.7",
         "@types/lodash.isplainobject": "4.0.7",
         "@types/node": "16.18.58",
         "@typescript-eslint/eslint-plugin": "6.7.5",
@@ -3077,6 +3079,15 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.188.tgz",
       "integrity": "sha512-zmEmF5OIM3rb7SbLCFYoQhO4dGt2FRM9AMkxvA3LaADOF1n8in/zGJlWji9fmafLoNyz+FoL6FE0SLtGIArD7w==",
       "dev": true
+    },
+    "node_modules/@types/lodash.clonedeep": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
+      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/lodash.isplainobject": {
       "version": "4.0.7",
@@ -8778,6 +8789,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -13774,6 +13790,15 @@
       "integrity": "sha512-zmEmF5OIM3rb7SbLCFYoQhO4dGt2FRM9AMkxvA3LaADOF1n8in/zGJlWji9fmafLoNyz+FoL6FE0SLtGIArD7w==",
       "dev": true
     },
+    "@types/lodash.clonedeep": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.7.tgz",
+      "integrity": "sha512-ccNqkPptFIXrpVqUECi60/DFxjNKsfoQxSQsgcBJCX/fuX1wgyQieojkcWH/KpE3xzLoWN/2k+ZeGqIN3paSvw==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/lodash.isplainobject": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.7.tgz",
@@ -17976,6 +18001,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@changesets/changelog-github": "0.4.8",
     "@changesets/cli": "2.26.2",
     "@types/jest": "29.5.5",
-    "@types/lodash.clonedeep": "^4.5.7",
+    "@types/lodash.clonedeep": "4.5.7",
     "@types/lodash.isplainobject": "4.0.7",
     "@types/node": "16.18.58",
     "@typescript-eslint/eslint-plugin": "6.7.5",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@changesets/changelog-github": "0.4.8",
     "@changesets/cli": "2.26.2",
     "@types/jest": "29.5.5",
+    "@types/lodash.clonedeep": "^4.5.7",
     "@types/lodash.isplainobject": "4.0.7",
     "@types/node": "16.18.58",
     "@typescript-eslint/eslint-plugin": "6.7.5",
@@ -59,6 +60,7 @@
     "@apollo/utils.withrequired": "^3.0.0",
     "@types/http-cache-semantics": "^4.0.1",
     "http-cache-semantics": "^4.1.1",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.isplainobject": "^4.0.6",
     "node-fetch": "^2.6.7"
   },

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -4,12 +4,13 @@ import type {
   FetcherResponse,
 } from '@apollo/utils.fetcher';
 import type { KeyValueCache } from '@apollo/utils.keyvaluecache';
+import type { Logger } from '@apollo/utils.logger';
 import type { WithRequired } from '@apollo/utils.withrequired';
 import { GraphQLError } from 'graphql';
+import type { Options as HttpCacheSemanticsOptions } from 'http-cache-semantics';
+import cloneDeep from 'lodash.clonedeep';
 import isPlainObject from 'lodash.isplainobject';
 import { HTTPCache } from './HTTPCache';
-import type { Logger } from '@apollo/utils.logger';
-import type { Options as HttpCacheSemanticsOptions } from 'http-cache-semantics';
 
 export type ValueOrPromise<T> = T | Promise<T>;
 
@@ -326,11 +327,7 @@ export abstract class RESTDataSource<CO extends CacheOptions = CacheOptions> {
   }
 
   protected cloneParsedBody<TResult>(parsedBody: TResult) {
-    if (typeof parsedBody === 'string') {
-      return parsedBody;
-    } else {
-      return JSON.parse(JSON.stringify(parsedBody));
-    }
+    return cloneDeep(parsedBody);
   }
 
   protected shouldJSONSerializeBody(body: RequestWithBody['body']): boolean {

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -327,7 +327,7 @@ export abstract class RESTDataSource<CO extends CacheOptions = CacheOptions> {
   }
 
   protected cloneParsedBody<TResult>(parsedBody: TResult) {
-    // consider using `structuredClone()` when we drop support for Node 16 
+    // consider using `structuredClone()` when we drop support for Node 16
     return cloneDeep(parsedBody);
   }
 

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -327,6 +327,7 @@ export abstract class RESTDataSource<CO extends CacheOptions = CacheOptions> {
   }
 
   protected cloneParsedBody<TResult>(parsedBody: TResult) {
+    // consider using `structuredClone()` when we drop support for Node 16 
     return cloneDeep(parsedBody);
   }
 


### PR DESCRIPTION
`JSON.parse(JSON.stringify())` is a bad way to clone objects.

There are many reasons why it is bad. For example: [why-json-parse-json-stringify-is-a-bad-practice-to-clone-an-object-in-javascript](https://medium.com/@pmzubar/why-json-parse-json-stringify-is-a-bad-practice-to-clone-an-object-in-javascript-b28ac5e36521)

I understand this method can be overridden but I don't think we should use a flawed approach as the default.
