### PR TITLE
feat: add ability to skip http cache on request

### DIFF
--- a/.changeset/tiny-queens-attend.md
+++ b/.changeset/tiny-queens-attend.md
@@ -1,0 +1,5 @@
+---
+"@apollo/datasource-rest": minor
+---
+
+Allow cache to be skipped on RestDataSource HTTP requests

--- a/src/HTTPCache.ts
+++ b/src/HTTPCache.ts
@@ -75,7 +75,7 @@ export class HTTPCache<CO extends CacheOptions = CacheOptions> {
       return { response: await this.httpFetch(urlString, requestOpts) };
     }
 
-    const entry = await this.keyValueCache.get(cacheKey);
+    const entry = requestOpts.skipCache !== true ? await this.keyValueCache.get(cacheKey) : undefined;
     if (!entry) {
       // There's nothing in our cache. Fetch the URL and save it to the cache if
       // we're allowed.

--- a/src/HTTPCache.ts
+++ b/src/HTTPCache.ts
@@ -75,7 +75,10 @@ export class HTTPCache<CO extends CacheOptions = CacheOptions> {
       return { response: await this.httpFetch(urlString, requestOpts) };
     }
 
-    const entry = requestOpts.skipCache !== true ? await this.keyValueCache.get(cacheKey) : undefined;
+    const entry =
+      requestOpts.skipCache !== true
+        ? await this.keyValueCache.get(cacheKey)
+        : undefined;
     if (!entry) {
       // There's nothing in our cache. Fetch the URL and save it to the cache if
       // we're allowed.

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -46,6 +46,11 @@ export type RequestOptions<CO extends CacheOptions = CacheOptions> =
           request: RequestOptions<CO>,
         ) => ValueOrPromise<CO | undefined>);
     /**
+     * Do not check the cache ignoring TTL or other cache settings
+     * Useful when you suspect a value may be cached but you want to force fresh data
+     */
+    skipCache?: boolean;
+    /**
      * If provided, this is passed through as the third argument to `new
      * CachePolicy()` from the `http-cache-semantics` npm package as part of the
      * HTTP-header-sensitive cache.

--- a/src/__tests__/HTTPCache.test.ts
+++ b/src/__tests__/HTTPCache.test.ts
@@ -130,6 +130,36 @@ describe('HTTPCache', () => {
       expect(response.headers.get('age')).toEqual('10');
     });
 
+    it('fetches fresh response when TTL not expired but skipCache true', async () => {
+      mockGetAdaLovelace({
+        'cache-control': 'private, no-cache',
+        'set-cookie': 'foo',
+      });
+
+      const { cacheWritePromise } = await httpCache.fetch(
+        adaUrl,
+        {},
+        {
+          cacheOptions: {
+            ttl: 30,
+          },
+        },
+      );
+
+      await cacheWritePromise;
+      jest.advanceTimersByTime(10000);
+
+      mockGetAlanTuring({
+        'cache-control': 'private, no-cache',
+        'set-cookie': 'foo',
+      });
+
+      const { response } = await httpCache.fetch(adaUrl, { skipCache: true });
+
+      expect(await response.json()).toEqual({ name: 'Alan Turing' });
+      expect(response.headers.get('age')).toBeNull();
+    });
+
     it('fetches a fresh response from the origin when the overridden TTL expired', async () => {
       mockGetAdaLovelace({
         'cache-control': 'private, no-cache',


### PR DESCRIPTION
Add a new request prop that will skip http headers or previous TTL cached items and fetch fresh data