### PR TITLE
Add metadata if response came from cache

### DIFF
--- a/src/HTTPCache.ts
+++ b/src/HTTPCache.ts
@@ -29,6 +29,7 @@ interface SneakyCachePolicy extends CachePolicy {
 
 interface ResponseWithCacheWritePromise {
   response: FetcherResponse;
+  responseFromCache?: Boolean;
   cacheWritePromise?: Promise<void>;
 }
 
@@ -72,7 +73,7 @@ export class HTTPCache<CO extends CacheOptions = CacheOptions> {
     // refreshing headers with HEAD requests, responding to HEADs with cached
     // and valid GETs, etc.)
     if (requestOpts.method === 'HEAD') {
-      return { response: await this.httpFetch(urlString, requestOpts) };
+      return { response: await this.httpFetch(urlString, requestOpts), responseFromCache: false };
     }
 
     const entry =
@@ -127,6 +128,7 @@ export class HTTPCache<CO extends CacheOptions = CacheOptions> {
           status: policy._status,
           headers: cachePolicyHeadersToNodeFetchHeadersInit(headers),
         }),
+        responseFromCache: true
       };
     } else {
       // We aren't sure that we're allowed to use the cached response, so we are


### PR DESCRIPTION
This should be the only place we need to add `responseFromCache: true` as all other places do re-update and store new cache entries.

Still missing test but sharing for early review