### PR TITLE
Add responseFromCache metadata to DataSourceFetchResult

### DIFF
--- a/.changeset/two-pans-boil.md
+++ b/.changeset/two-pans-boil.md
@@ -1,0 +1,5 @@
+---
+'@apollo/datasource-rest': minor
+---
+
+Add responseFromCache metadata to DataSourceFetchResult

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/datasource-rest",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/datasource-rest",
-      "version": "6.3.0",
+      "version": "6.4.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/utils.fetcher": "^3.0.0",

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -160,6 +160,7 @@ export interface DataSourceFetchResult<TResult> {
   response: FetcherResponse;
   requestDeduplication: RequestDeduplicationResult;
   httpCache: HTTPCacheResult;
+  responseFromCache: Boolean | undefined;
 }
 
 // RESTDataSource has two layers of caching. The first layer is purely in-memory
@@ -536,16 +537,13 @@ export abstract class RESTDataSource<CO extends CacheOptions = CacheOptions> {
           ? outgoingRequest.cacheOptions
           : this.cacheOptionsFor?.bind(this);
         try {
-          const { response, cacheWritePromise } = await this.httpCache.fetch(
-            url,
-            outgoingRequest,
-            {
+          const { response, cacheWritePromise, responseFromCache } =
+            await this.httpCache.fetch(url, outgoingRequest, {
               cacheKey,
               cacheOptions,
               httpCacheSemanticsCachePolicyOptions:
                 outgoingRequest.httpCacheSemanticsCachePolicyOptions,
-            },
-          );
+            });
 
           if (cacheWritePromise) {
             this.catchCacheWritePromiseErrors(cacheWritePromise);
@@ -566,6 +564,7 @@ export abstract class RESTDataSource<CO extends CacheOptions = CacheOptions> {
             httpCache: {
               cacheWritePromise,
             },
+            responseFromCache,
           };
         } catch (error) {
           this.didEncounterError(error as Error, outgoingRequest, url);


### PR DESCRIPTION
Hello,

I tried to use the 6.4.0 version's `responseFromCache` metadata, in a customised solution where our approach is basically

```ts

  override async fetch<TResult>(path: string, request: DataSourceRequest = {}) {
    // Create messageId that will be used during the whole request lifecycle
    const messageId = this.getAzureMessageId();

    // Attach messageId to the request headers. Include other headers from client's request.
    request.headers = {
      ...request.headers,
      'x-message-id': messageId,
    };

    // Execute the request
    const result: DataSourceFetchResult<TResult> = await this.semaphore.withLock(() => super.fetch(path, request));

    // Only log request and response for no-depduplicated, successful requests
    if (!result.requestDeduplication.deduplicatedAgainstPreviousRequest) {
      this.logRequest(request as ApolloRequestOptions, path).finally();
      this.logResponse(request as ApolloRequestOptions, result).finally();
    }

    return result;
  }
```

In this implementation it would be required that I actually get this meta data part of DataSourceFetchResult -- So this can be sent to our logging platform correctly. 

@smyrick Have I understood something wrong in this, and is there way for me to use your implementation here without these changes?