### PR TITLE
Fix response from cache metadata with tests

### DIFF
--- a/.changeset/fluffy-news-cry.md
+++ b/.changeset/fluffy-news-cry.md
@@ -1,0 +1,5 @@
+---
+'@apollo/datasource-rest': patch
+---
+
+Add responseFromCache to DataSourceFetchResult

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apollo/datasource-rest",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@apollo/datasource-rest",
-      "version": "6.3.0",
+      "version": "6.4.0",
       "license": "MIT",
       "dependencies": {
         "@apollo/utils.fetcher": "^3.0.0",

--- a/src/HTTPCache.ts
+++ b/src/HTTPCache.ts
@@ -29,7 +29,7 @@ interface SneakyCachePolicy extends CachePolicy {
 
 interface ResponseWithCacheWritePromise {
   response: FetcherResponse;
-  responseFromCache?: Boolean;
+  responseFromCache?: boolean;
   cacheWritePromise?: Promise<void>;
 }
 
@@ -247,6 +247,7 @@ export class HTTPCache<CO extends CacheOptions = CacheOptions> {
     const returnedResponse = response.clone();
     return {
       response: returnedResponse,
+      responseFromCache: false,
       cacheWritePromise: this.readResponseAndWriteToCache({
         response,
         policy,

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -160,6 +160,7 @@ export interface DataSourceFetchResult<TResult> {
   response: FetcherResponse;
   requestDeduplication: RequestDeduplicationResult;
   httpCache: HTTPCacheResult;
+  responseFromCache?: boolean;
 }
 
 // RESTDataSource has two layers of caching. The first layer is purely in-memory
@@ -536,16 +537,13 @@ export abstract class RESTDataSource<CO extends CacheOptions = CacheOptions> {
           ? outgoingRequest.cacheOptions
           : this.cacheOptionsFor?.bind(this);
         try {
-          const { response, cacheWritePromise } = await this.httpCache.fetch(
-            url,
-            outgoingRequest,
-            {
+          const { response, responseFromCache, cacheWritePromise } =
+            await this.httpCache.fetch(url, outgoingRequest, {
               cacheKey,
               cacheOptions,
               httpCacheSemanticsCachePolicyOptions:
                 outgoingRequest.httpCacheSemanticsCachePolicyOptions,
-            },
-          );
+            });
 
           if (cacheWritePromise) {
             this.catchCacheWritePromiseErrors(cacheWritePromise);
@@ -566,6 +564,7 @@ export abstract class RESTDataSource<CO extends CacheOptions = CacheOptions> {
             httpCache: {
               cacheWritePromise,
             },
+            responseFromCache,
           };
         } catch (error) {
           this.didEncounterError(error as Error, outgoingRequest, url);


### PR DESCRIPTION
Implementing https://github.com/apollographql/datasource-rest/pull/380 but with tests and change from a typescript `Boolean` to a standard `boolean`

------

In this PR we added new metadata `responseFromCache`, however that data is not making it all the way up to user space and the exposed types of the library: https://github.com/apollographql/datasource-rest/pull/371

This fixes that bug and adds more tests to validate which actually makes the tests more clear they have checked the cache