### PR TITLE
chore: update TS lib+target to ES2021

### DIFF
--- a/.changeset/wild-tools-cheer.md
+++ b/.changeset/wild-tools-cheer.md
@@ -1,0 +1,5 @@
+---
+'@apollo/datasource-rest': patch
+---
+
+Update TS lib+target to ES2021

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    "target": "es2019",
+    "target": "es2021",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
@@ -20,7 +20,7 @@
     "forceConsistentCasingInFileNames": true,
     // TODO(esm): enable if this package is ever ESM-only
     // "verbatimModuleSyntax": true,
-    "lib": ["es2019", "esnext.asynciterable"],
+    "lib": ["es2021"],
     "types": ["node"],
     "baseUrl": ".",
   }


### PR DESCRIPTION
Since the project requires node 16.14+ this can be used. It affects the output where the newer syntax can now be used.

Technically, node 16.14 could have ES2022 enabled, but it's likely not required at this time.

This is pretty much the same as the template change[^1].

[^1]:https://github.com/apollographql/typescript-repo-template/commit/c83393b0f6e8df2011ea4b9cda5607ad07f848e5

Change of the output is cosmetic, will be much nicer to read while debugging etc.
<img width="892" alt="image" src="https://github.com/user-attachments/assets/da409f7b-743c-4acd-9f1c-298a980e4498" />
