### PR TITLE
feat!: use Web API's fetch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,9 +94,8 @@ workflows:
           matrix:
             parameters:
               node-version:
-                - "16"
-                - "18"
                 - "20"
+                - "22"
       - Prettier
       - Lint
       - Spell Check

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,7 @@
         "@types/http-cache-semantics": "^4.0.1",
         "http-cache-semantics": "^4.1.1",
         "lodash.clonedeep": "^4.5.0",
-        "lodash.isplainobject": "^4.0.6",
-        "node-fetch": "^2.6.7"
+        "lodash.isplainobject": "^4.0.6"
       },
       "devDependencies": {
         "@apollo/server": "4.11.3",
@@ -26,7 +25,7 @@
         "@types/jest": "29.5.14",
         "@types/lodash.clonedeep": "4.5.9",
         "@types/lodash.isplainobject": "4.0.9",
-        "@types/node": "16.18.125",
+        "@types/node": "20.14.8",
         "@typescript-eslint/eslint-plugin": "6.21.0",
         "@typescript-eslint/parser": "6.21.0",
         "cspell": "8.17.3",
@@ -35,14 +34,14 @@
         "graphql": "16.10.0",
         "jest": "29.7.0",
         "jest-junit": "16.0.0",
-        "nock": "13.5.6",
+        "nock": "14.0.0",
         "prettier": "3.4.2",
         "ts-jest": "29.2.5",
         "ts-node": "10.9.2",
         "typescript": "5.7.3"
       },
       "engines": {
-        "node": ">=16.14"
+        "node": ">=20"
       },
       "peerDependencies": {
         "graphql": "^16.5.0"
@@ -2767,6 +2766,24 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.37.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.6.tgz",
+      "integrity": "sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2801,6 +2818,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -3088,10 +3130,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.125",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.125.tgz",
-      "integrity": "sha512-w7U5ojboSPfZP4zD98d+/cjcN2BDW6lKH2M0ubipt8L8vUC7qUAC6ENKGSJL4tEktH2Saw2K4y1uwSjyRGKMhw==",
-      "dev": true
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.2",
@@ -6061,6 +6107,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -8299,17 +8352,18 @@
       }
     },
     "node_modules/nock": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
-      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0.tgz",
+      "integrity": "sha512-3Z2ZoZoYTR/y2I+NI16+6IzfZFKBX7MrADtoBAm7v/QKqxQUhKw+Dh+847PPS1j/FDutjfIXfrh3CJF74yITWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "debug": "^4.1.0",
+        "@mswjs/interceptors": "^0.37.3",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       },
       "engines": {
-        "node": ">= 10.13"
+        "node": ">= 18"
       }
     },
     "node_modules/node-abort-controller": {
@@ -8322,6 +8376,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -8458,6 +8513,13 @@
       "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
       "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
       "dev": true
+    },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-filter": {
       "version": "2.1.0",
@@ -9241,6 +9303,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -9456,7 +9525,8 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "node_modules/ts-api-utils": {
       "version": "1.0.1",
@@ -9626,6 +9696,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -9733,7 +9810,8 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
@@ -9748,6 +9826,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -12150,6 +12229,20 @@
         }
       }
     },
+    "@mswjs/interceptors": {
+      "version": "0.37.6",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.37.6.tgz",
+      "integrity": "sha512-wK+5pLK5XFmgtH3aQ2YVvA3HohS3xqV/OxuVOdNx9Wpnz7VE/fnC+e1A7ln6LFYeck7gOJ/dsZV6OLplOtAJ2w==",
+      "dev": true,
+      "requires": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -12175,6 +12268,28 @@
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
       }
+    },
+    "@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true
+    },
+    "@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "requires": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -12462,10 +12577,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.18.125",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.125.tgz",
-      "integrity": "sha512-w7U5ojboSPfZP4zD98d+/cjcN2BDW6lKH2M0ubipt8L8vUC7qUAC6ENKGSJL4tEktH2Saw2K4y1uwSjyRGKMhw==",
-      "dev": true
+      "version": "20.14.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.8.tgz",
+      "integrity": "sha512-DO+2/jZinXfROG7j7WKFn/3C6nFwxy2lLpgLjEXJz+0XKphZlTLJ14mo8Vfg8X5BWN6XjyESXq+LcYdT7tR3bA==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/node-fetch": {
       "version": "2.6.2",
@@ -14647,6 +14765,12 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -16312,12 +16436,12 @@
       "dev": true
     },
     "nock": {
-      "version": "13.5.6",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
-      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-14.0.0.tgz",
+      "integrity": "sha512-3Z2ZoZoYTR/y2I+NI16+6IzfZFKBX7MrADtoBAm7v/QKqxQUhKw+Dh+847PPS1j/FDutjfIXfrh3CJF74yITWg==",
       "dev": true,
       "requires": {
-        "debug": "^4.1.0",
+        "@mswjs/interceptors": "^0.37.3",
         "json-stringify-safe": "^5.0.1",
         "propagate": "^2.0.0"
       }
@@ -16332,6 +16456,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"
       }
@@ -16426,6 +16551,12 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.5.0.tgz",
       "integrity": "sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==",
+      "dev": true
+    },
+    "outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
       "dev": true
     },
     "p-filter": {
@@ -16989,6 +17120,12 @@
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "dev": true
     },
+    "strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true
+    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -17139,7 +17276,8 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "ts-api-utils": {
       "version": "1.0.1",
@@ -17229,6 +17367,12 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true
     },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -17315,7 +17459,8 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
     },
     "whatwg-mimetype": {
       "version": "3.0.0",
@@ -17327,6 +17472,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "engines": {
-    "node": ">=16.14"
+    "node": ">=20"
   },
   "scripts": {
     "build": "tsc --build tsconfig.build.json",
@@ -39,7 +39,7 @@
     "@types/jest": "29.5.14",
     "@types/lodash.clonedeep": "4.5.9",
     "@types/lodash.isplainobject": "4.0.9",
-    "@types/node": "16.18.125",
+    "@types/node": "20.14.8",
     "@typescript-eslint/eslint-plugin": "6.21.0",
     "@typescript-eslint/parser": "6.21.0",
     "cspell": "8.17.3",
@@ -48,7 +48,7 @@
     "graphql": "16.10.0",
     "jest": "29.7.0",
     "jest-junit": "16.0.0",
-    "nock": "13.5.6",
+    "nock": "14.0.0",
     "prettier": "3.4.2",
     "ts-jest": "29.2.5",
     "ts-node": "10.9.2",
@@ -62,8 +62,7 @@
     "@types/http-cache-semantics": "^4.0.1",
     "http-cache-semantics": "^4.1.1",
     "lodash.clonedeep": "^4.5.0",
-    "lodash.isplainobject": "^4.0.6",
-    "node-fetch": "^2.6.7"
+    "lodash.isplainobject": "^4.0.6"
   },
   "peerDependencies": {
     "graphql": "^16.5.0"

--- a/renovate.json5
+++ b/renovate.json5
@@ -25,12 +25,7 @@
     // versions we support.
     {
       "matchPackageNames": ["@types/node"],
-      "allowedVersions": "16.x"
-    },
-    // v3 is ESM only
-    {
-      "matchPackageNames": ["node-fetch"],
-      "allowedVersions": "2.x"
+      "allowedVersions": "20.x"
     },
   ],
 }

--- a/src/RESTDataSource.ts
+++ b/src/RESTDataSource.ts
@@ -1,5 +1,4 @@
 import type {
-  Fetcher,
   FetcherRequestInit,
   FetcherResponse,
 } from '@apollo/utils.fetcher';
@@ -142,7 +141,7 @@ const NODE_ENV = process.env.NODE_ENV;
 
 export interface DataSourceConfig {
   cache?: KeyValueCache;
-  fetch?: Fetcher;
+  fetch?: typeof fetch;
   logger?: Logger;
 }
 

--- a/src/__tests__/HTTPCache.test.ts
+++ b/src/__tests__/HTTPCache.test.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import nock from 'nock';
 import { HTTPCache } from '../HTTPCache';
 import type { CacheOptions } from '../RESTDataSource';

--- a/src/__tests__/RESTDataSource.test.ts
+++ b/src/__tests__/RESTDataSource.test.ts
@@ -8,12 +8,10 @@ import {
   RESTDataSource,
 } from '../RESTDataSource';
 
-import FormData from 'form-data';
 import { GraphQLError } from 'graphql';
 import nock from 'nock';
 import { nockAfterEach, nockBeforeEach } from './nockAssertions';
 import type { WithRequired } from '@apollo/utils.withrequired';
-import { Headers as NodeFetchHeaders } from 'node-fetch';
 import type { Logger } from '@apollo/utils.logger';
 
 const apiUrl = 'https://api.example.com';
@@ -1948,18 +1946,7 @@ describe('RESTDataSource', () => {
           const { headers } = response;
           expect(headers.get('hello')).toBe('dolly, world');
           // The general Fetcher interface only lets you get the combined header values.
-          expect(headers.get('set-cookie')).toBe('first=foo, second=bar');
-
-          if (!(headers instanceof NodeFetchHeaders)) {
-            fail(
-              'headers should be a NodeFetchHeaders when fetcher not overridden',
-            );
-          }
-          expect(headers.raw()['hello']).toStrictEqual(['dolly, world']);
-          expect(headers.raw()['set-cookie']).toStrictEqual([
-            'first=foo',
-            'second=bar',
-          ]);
+          expect(headers.get('set-cookie')).toBe('first=foo,second=bar');
         });
 
         it('for a cacheable but not de-duped request', async () => {
@@ -1988,18 +1975,8 @@ describe('RESTDataSource', () => {
             const { headers } = response;
             expect(headers.get('hello')).toBe('dolly, world');
             // The general Fetcher interface only lets you get the combined header values.
-            expect(headers.get('set-cookie')).toBe('first=foo, second=bar');
+            expect(headers.get('set-cookie')).toBe('first=foo,second=bar');
 
-            if (!(headers instanceof NodeFetchHeaders)) {
-              fail(
-                'headers should be a NodeFetchHeaders when fetcher not overridden',
-              );
-            }
-            expect(headers.raw()['hello']).toStrictEqual(['dolly, world']);
-            expect(headers.raw()['set-cookie']).toStrictEqual([
-              'first=foo',
-              'second=bar',
-            ]);
             await httpCache.cacheWritePromise;
           }
 
@@ -2010,18 +1987,7 @@ describe('RESTDataSource', () => {
             const { headers } = response;
             expect(headers.get('hello')).toBe('dolly, world');
             // The general Fetcher interface only lets you get the combined header values.
-            expect(headers.get('set-cookie')).toBe('first=foo, second=bar');
-
-            if (!(headers instanceof NodeFetchHeaders)) {
-              fail(
-                'headers should be a NodeFetchHeaders when fetcher not overridden',
-              );
-            }
-            expect(headers.raw()['hello']).toStrictEqual(['dolly, world']);
-            expect(headers.raw()['set-cookie']).toStrictEqual([
-              'first=foo',
-              'second=bar',
-            ]);
+            expect(headers.get('set-cookie')).toBe('first=foo,second=bar');
           }
         });
       });

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    "target": "es2019",
+    "target": "es2023",
     "module": "commonjs",
     "moduleResolution": "node",
     "esModuleInterop": true,
@@ -20,7 +20,7 @@
     "forceConsistentCasingInFileNames": true,
     // TODO(esm): enable if this package is ever ESM-only
     // "verbatimModuleSyntax": true,
-    "lib": ["es2019", "esnext.asynciterable"],
+    "lib": ["es2023"],
     "types": ["node"],
     "baseUrl": ".",
   }


### PR DESCRIPTION
Currently not working due to no possible way to set the `url` prop of Response in cases where the lib tries to fake it once retrieved from cache.

Included:
- drop node-fetch@v2
- update nock to v14
- raise minimal node version to 20 (as 18 is almost EoL)
- raise ES target to match node 20